### PR TITLE
Fix response for user acrion

### DIFF
--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -223,6 +223,7 @@ struct FolderView: View {
                         folder: folder,
                         branch: branch,
                         onSelect: { branch in
+                            showing.branches = false
                             Task {
                                 do {
                                     try await Process.output(
@@ -232,9 +233,9 @@ struct FolderView: View {
                                     self.error = error
                                 }
                                 await refreshModels()
-                                showing.branches = false
                             }
                         }, onSelectMergeInto: { mergeIntoBranch in
+                            showing.branches = false
                             Task {
                                 do {
                                     try await Process.output(GitMerge(directory: folder.url, branchName: mergeIntoBranch.name))
@@ -242,7 +243,6 @@ struct FolderView: View {
                                     self.error = error
                                 }
                                 await refreshModels()
-                                showing.branches = false
                             }
                         },
                         onSelectNewBranchFrom: { from in
@@ -260,6 +260,7 @@ struct FolderView: View {
                         branch: branch,
                         isRemote: true,
                         onSelect: { branch in
+                            showing.branches = false
                             Task {
                                 do {
                                     try await Process.output(
@@ -269,9 +270,9 @@ struct FolderView: View {
                                     self.error = error
                                 }
                                 await refreshModels()
-                                showing.branches = false
                             }
                         }, onSelectMergeInto: { mergeIntoBranch in
+                            showing.branches = false
                             Task {
                                 do {
                                     try await Process.output(GitMerge(directory: folder.url, branchName: mergeIntoBranch.name))
@@ -279,7 +280,6 @@ struct FolderView: View {
                                     self.error = error
                                 }
                                 await refreshModels()
-                                showing.branches = false
                             }
                         },
                         onSelectNewBranchFrom: { from in


### PR DESCRIPTION
This pull request includes changes to the `FolderView` in the `GitClient/Views/Folder/FolderView.swift` file to improve the handling of the `showing.branches` state. The most important changes involve moving the assignment of `showing.branches = false` to ensure it is set before asynchronous tasks are executed.

State management improvements:

* [`GitClient/Views/Folder/FolderView.swift`](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eR226): Moved `showing.branches = false` before initiating the asynchronous task in the `onSelect` closure.
* [`GitClient/Views/Folder/FolderView.swift`](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eL235-L245): Moved `showing.branches = false` before initiating the asynchronous task in the `onSelectMergeInto` closure.
* [`GitClient/Views/Folder/FolderView.swift`](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eR263): Moved `showing.branches = false` before initiating the asynchronous task in the `onSelect` closure for remote branches.
* [`GitClient/Views/Folder/FolderView.swift`](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eL272-L282): Moved `showing.branches = false` before initiating the asynchronous task in the `onSelectMergeInto` closure for remote branches.Added logic to hide branches after a branch or merge action is selected to improve user experience in the FolderView component.