### PR TITLE
Revision range search token

### DIFF
--- a/GitClient.xcodeproj/project.pbxproj
+++ b/GitClient.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		61A5DF502D9D5A3800FAF078 /* SearchToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5DF4F2D9D5A3800FAF078 /* SearchToken.swift */; };
 		61A5DF522D9DFB2100FAF078 /* SearchTokensHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5DF512D9DFB0A00FAF078 /* SearchTokensHandler.swift */; };
 		61A5DF542D9DFD1B00FAF078 /* SearchTokensHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A5DF532D9DFD1B00FAF078 /* SearchTokensHandlerTests.swift */; };
+		61AC65812DA9F83700D80470 /* LogStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AC65802DA9F82E00D80470 /* LogStoreTests.swift */; };
 		61B3C55E2CB4A74C00021B36 /* GitShow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3C55D2CB4A74700021B36 /* GitShow.swift */; };
 		61B3C5602CB4A9CE00021B36 /* CommitDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3C55F2CB4A9C500021B36 /* CommitDetail.swift */; };
 		61B3C5622CB557D100021B36 /* CommitDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3C5612CB557CA00021B36 /* CommitDetailView.swift */; };
@@ -214,6 +215,7 @@
 		61A5DF4F2D9D5A3800FAF078 /* SearchToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchToken.swift; sourceTree = "<group>"; };
 		61A5DF512D9DFB0A00FAF078 /* SearchTokensHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTokensHandler.swift; sourceTree = "<group>"; };
 		61A5DF532D9DFD1B00FAF078 /* SearchTokensHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTokensHandlerTests.swift; sourceTree = "<group>"; };
+		61AC65802DA9F82E00D80470 /* LogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogStoreTests.swift; sourceTree = "<group>"; };
 		61B3C55D2CB4A74700021B36 /* GitShow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitShow.swift; sourceTree = "<group>"; };
 		61B3C55F2CB4A9C500021B36 /* CommitDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetail.swift; sourceTree = "<group>"; };
 		61B3C5612CB557CA00021B36 /* CommitDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailView.swift; sourceTree = "<group>"; };
@@ -330,6 +332,7 @@
 				614DE8152DA0C2E700FC582E /* GitShowShortstatTests.swift */,
 				61A5DF532D9DFD1B00FAF078 /* SearchTokensHandlerTests.swift */,
 				613D140B2DA7AB3F008D561E /* SyncStateTests.swift */,
+				61AC65802DA9F82E00D80470 /* LogStoreTests.swift */,
 			);
 			path = GitClientTests;
 			sourceTree = "<group>";
@@ -768,6 +771,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61AC65812DA9F83700D80470 /* LogStoreTests.swift in Sources */,
 				61347F0028D5D16D00625FC4 /* DiffTests.swift in Sources */,
 				61B5BBB72C9B97310087A9F6 /* BranchTests.swift in Sources */,
 				619759562C8C9A9300E9CA4F /* GitDiffNumStatTests.swift in Sources */,

--- a/GitClient/Models/Observables/LogStore.swift
+++ b/GitClient/Models/Observables/LogStore.swift
@@ -17,7 +17,7 @@ import Observation
             switch token.kind {
             case .grep, .grepAllMatch:
                 return true
-            case .g, .s, .author:
+            case .g, .s, .author, .revisionRange:
                 return false
             }
         }.map { $0.text }

--- a/GitClient/Models/Observables/LogStore.swift
+++ b/GitClient/Models/Observables/LogStore.swift
@@ -10,7 +10,7 @@ import Observation
 
 @MainActor
 @Observable class LogStore {
-    let number = 500
+    var number = 500
     var directory: URL?
     private var grep: [String] {
         searchTokens.filter { token in

--- a/GitClient/Models/SearchKind.swift
+++ b/GitClient/Models/SearchKind.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum SearchKind {
-    case grep, grepAllMatch, s, g, author
+    case grep, grepAllMatch, s, g, author, revisionRange
 }

--- a/GitClient/Models/SearchTokensHandler.swift
+++ b/GitClient/Models/SearchTokensHandler.swift
@@ -6,7 +6,7 @@
 //
 
 struct SearchTokensHandler {
-    static func newToken(old: [SearchToken], new: [SearchToken]) -> SearchToken? {
+    static private func newToken(old: [SearchToken], new: [SearchToken]) -> SearchToken? {
         new.first { !old.contains($0) }
     }
 

--- a/GitClient/Models/SearchTokensHandler.swift
+++ b/GitClient/Models/SearchTokensHandler.swift
@@ -20,14 +20,14 @@ struct SearchTokensHandler {
                         var updateToken = token
                         updateToken.kind = newToken.kind
                         return updateToken
-                    default:
+                    case .s, .g, .author, .revisionRange:
                         return token
                     }
                 }
             case .s:
                 return newTokens.filter { token in
                     switch token.kind {
-                    case .grep, .grepAllMatch, .author:
+                    case .grep, .grepAllMatch, .author, .revisionRange:
                         return true
                     case .s:
                         return token == newToken
@@ -38,7 +38,7 @@ struct SearchTokensHandler {
             case .g:
                 return newTokens.filter { token in
                     switch token.kind {
-                    case .grep, .grepAllMatch, .author:
+                    case .grep, .grepAllMatch, .author, .revisionRange:
                         return true
                     case .g:
                         return token == newToken
@@ -49,9 +49,18 @@ struct SearchTokensHandler {
             case .author:
                 return newTokens.filter { token in
                     switch token.kind {
-                    case .grep, .grepAllMatch, .g, .s:
+                    case .grep, .grepAllMatch, .g, .s, .revisionRange:
                         return true
                     case .author:
+                        return token == newToken
+                    }
+                }
+            case .revisionRange:
+                return newTokens.filter { token in
+                    switch token.kind {
+                    case .grep, .grepAllMatch, .g, .s, .author:
+                        return true
+                    case .revisionRange:
                         return token == newToken
                     }
                 }

--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -53,6 +53,7 @@ struct FolderView: View {
                 Text("Changed").tag(SearchKind.g)
                 Text("Changed(O)").tag(SearchKind.s)
                 Text("Author").tag(SearchKind.author)
+                Text("Revision Range").tag(SearchKind.revisionRange)
             } label: {
                 Text(token.text)
             }
@@ -69,6 +70,8 @@ struct FolderView: View {
                     .help("Search commits where the number of occurrences of the specified regex has changed (added/removed).")
                 Text("Author: " + searchText).searchCompletion(SearchToken(kind: .author, text: searchText))
                     .help("Search commits by author matching the given pattern (regular expression).")
+                Text("Revision Range: " + searchText).searchCompletion(SearchToken(kind: .revisionRange, text: searchText))
+                    .help("Search commits within the revision range specified by Git syntax. e.g., main.., abc123..def456")
             }
         })
         .task {

--- a/GitClientTests/LogStoreTests.swift
+++ b/GitClientTests/LogStoreTests.swift
@@ -1,0 +1,109 @@
+//
+//  LogStoreTests.swift
+//  GitClient
+//
+//  Created by Makoto Aoyama on 2025/04/12.
+//
+
+import Testing
+import Foundation
+@testable import Tempo
+
+@MainActor
+struct LogStoreTests {
+    @Test func refresh() async throws {
+        try await Process.output(GitSwitch(directory: .testFixture!, branchName: "_test-fixture"))
+        let store = LogStore()
+        store.directory = .testFixture!
+        store.searchTokens = [] // 検索トークンがなければ全件取得
+
+        await store.refresh()
+
+        #expect(store.commits.count == 29)
+        #expect(store.logs().first == .committed(store.commits.first!))
+        #expect(store.error == nil)
+    }
+
+    @Test func refreshWithRevisionRange() async throws {
+        try await Process.output(GitSwitch(directory: .testFixture!, branchName: "_test-fixture"))
+        let store = LogStore()
+        store.directory = .testFixture!
+        store.searchTokens = [.init(kind: .revisionRange, text: "cfae930..")]
+
+        await store.refresh()
+
+        #expect(store.commits.count == 2)
+        #expect(store.error == nil)
+    }
+
+    @Test func updateAddsCommits() async throws {
+        try await Process.output(GitSwitch(directory: .testFixture!, branchName: "_test-fixture"))
+        let store = LogStore()
+        store.directory = .testFixture!
+        store.searchTokens = []
+
+        await store.refresh()
+        let oldCount = store.commits.count
+        await store.update()
+        let newCount = store.commits.count
+
+        #expect(newCount == oldCount)
+        #expect(store.error == nil)
+    }
+
+    @Test func loadMoreAppendsCommits() async throws {
+        try await Process.output(GitSwitch(directory: .testFixture!, branchName: "_test-fixture"))
+        let store = LogStore()
+        store.number = 10
+        store.directory = .testFixture!
+
+        await store.refresh()
+        #expect(store.commits.count == 10)
+
+        let first = store.commits.first
+        await store.logViewTask(.committed(first!))
+        #expect(store.commits.count == 10)
+
+        await store.update()
+        #expect(store.commits.count == 10)
+
+        let last = store.commits.last
+        await store.logViewTask(.committed(last!))
+        #expect(store.commits.count == 20)
+
+        let last2 = store.commits.last
+        await store.logViewTask(.committed(last2!))
+        #expect(store.commits.count == 29)
+
+        #expect(store.error == nil)
+    }
+
+    @Test func loadMoreAppendsCommitsWithRevisionRange() async throws {
+        try await Process.output(GitSwitch(directory: .testFixture!, branchName: "_test-fixture"))
+        let store = LogStore()
+        store.number = 1
+        store.directory = .testFixture!
+        store.searchTokens = [.init(kind: .revisionRange, text: "cfae930..")]
+
+        await store.refresh()
+        #expect(store.commits.count == 2)
+
+        let first = store.commits.first
+        await store.logViewTask(.committed(first!))
+        #expect(store.commits.count == 2)
+
+        await store.update()
+        #expect(store.commits.count == 2)
+
+        let last = store.commits.last
+        await store.logViewTask(.committed(last!))
+        #expect(store.commits.count == 2)
+
+        let last2 = store.commits.last
+        await store.logViewTask(.committed(last2!))
+        #expect(store.commits.count == 2)
+
+        #expect(store.error == nil)
+    }
+
+}


### PR DESCRIPTION
This pull request introduces several changes to the `GitClient` project, focusing on adding support for a new `revisionRange` search token and updating the `LogStore` functionality accordingly. Additionally, new tests for `LogStore` have been added to ensure the new functionality works as expected.

### Enhancements to `LogStore`:

* Added support for `revisionRange` in `LogStore`, including new methods and logic to handle commits within a specified revision range. (`GitClient/Models/Observables/LogStore.swift`) [[1]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522L13-R20) [[2]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522R37-R39) [[3]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522L50-R53) [[4]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522R62-R65) [[5]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522L73-R92) [[6]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522R102-R105) [[7]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522L119-R142)
* Introduced a new private method `loadCommitsWithSearchTokenRevisionRange` to load commits based on the `revisionRange` search token. (`GitClient/Models/Observables/LogStore.swift`)

### Updates to `SearchKind` and `SearchTokensHandler`:

* Added `revisionRange` as a new case in the `SearchKind` enum. (`GitClient/Models/SearchKind.swift`)
* Updated `SearchTokensHandler` to handle the new `revisionRange` search token. (`GitClient/Models/SearchTokensHandler.swift`) [[1]](diffhunk://#diff-f7bec91803b611b449f7c79471b9dadde937cf2beebc3b84d5f8b9988c1dd4abL9-R9) [[2]](diffhunk://#diff-f7bec91803b611b449f7c79471b9dadde937cf2beebc3b84d5f8b9988c1dd4abL23-R30) [[3]](diffhunk://#diff-f7bec91803b611b449f7c79471b9dadde937cf2beebc3b84d5f8b9988c1dd4abL41-R41) [[4]](diffhunk://#diff-f7bec91803b611b449f7c79471b9dadde937cf2beebc3b84d5f8b9988c1dd4abL52-R66)

### UI Changes:

* Added a new option for `revisionRange` in the `FolderView` UI to allow users to search commits within a specified revision range. (`GitClient/Views/Folder/FolderView.swift`) [[1]](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eR56) [[2]](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eR73-R74)

### Project Configuration:

* Added `LogStoreTests.swift` to the project configuration to ensure it is included in the build and test phases. (`GitClient.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R82) [[2]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R218) [[3]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R335) [[4]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R774)

### New Tests:

* Introduced `LogStoreTests.swift` with multiple test cases to verify the functionality of `LogStore`, including the new `revisionRange` functionality. (`GitClientTests/LogStoreTests.swift`)