### PR TITLE
Fix badge when detached

### DIFF
--- a/GitClient/Models/Branch.swift
+++ b/GitClient/Models/Branch.swift
@@ -8,17 +8,21 @@
 import Foundation
 
 struct Branch: Hashable, Identifiable {
+    let detachedPrefix = "(HEAD detached at "
+
     var id: String {
         name
     }
     var name: String
     var isCurrent: Bool
     var point: String {
-        let detachedPrefix = "(HEAD detached at "
-        if name.hasPrefix(detachedPrefix) {
+        if isDetached {
             return String(name.dropFirst(detachedPrefix.count).dropLast(1))
         }
         return name
+    }
+    var isDetached: Bool {
+        return name.hasPrefix(detachedPrefix)
     }
 }
 

--- a/GitClient/Models/Observables/SyncState.swift
+++ b/GitClient/Models/Observables/SyncState.swift
@@ -11,25 +11,25 @@ import Observation
 @MainActor
 @Observable class SyncState {
     var folderURL: URL?
-    var branchName: String?
+    var branch: Branch?
     var shouldPull = false
     var shouldPush = false
 
     func sync() async throws {
-        guard let folderURL, let branchName else {
+        guard let folderURL, let branch, !branch.isDetached else {
             shouldPull = false
             shouldPush = false
             return
         }
         try await Process.output(GitFetch(directory: folderURL))
 
-        let existRemoteBranch = try? await Process.output(GitShowref(directory: folderURL, pattern: "refs/remotes/origin/\(branchName)"))
+        let existRemoteBranch = try? await Process.output(GitShowref(directory: folderURL, pattern: "refs/remotes/origin/\(branch.name)"))
         guard existRemoteBranch != nil else {
             shouldPull = false
             shouldPush = true
             return
         }
-        shouldPull = !(try await Process.output(GitLog(directory: folderURL, revisionRange: "\(branchName)..origin/\(branchName)")).isEmpty)
-        shouldPush = !(try await Process.output(GitLog(directory: folderURL, revisionRange: "origin/\(branchName)..\(branchName)")).isEmpty)
+        shouldPull = !(try await Process.output(GitLog(directory: folderURL, revisionRange: "\(branch.name)..origin/\(branch.name)")).isEmpty)
+        shouldPush = !(try await Process.output(GitLog(directory: folderURL, revisionRange: "origin/\(branch.name)..\(branch.name)")).isEmpty)
     }
 }

--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -175,7 +175,7 @@ struct FolderView: View {
             branch = try await Process.output(GitBranch(directory: folder.url)).current
             logStore.directory = folder.url
             syncState.folderURL = folder.url
-            syncState.branchName = branch?.name ?? ""
+            syncState.branch = branch
 
             await logStore.refresh()
             if Task.isCancelled {

--- a/GitClientTests/SyncStateTests.swift
+++ b/GitClientTests/SyncStateTests.swift
@@ -60,4 +60,16 @@ struct SyncStateTests {
         #expect(state.shouldPull == true)
         #expect(state.shouldPush == false)
     }
+
+    @Test func syncDetached() async throws {
+        let tag = "v0.2.0"
+        try await Process.output(GitCheckout(directory: .testFixture!, commitHash: tag))
+        let state = SyncState()
+        state.folderURL = .testFixture!
+        state.branchName = try await Process.output(GitBranch(directory: .testFixture!)).current?.name
+        try await state.sync()
+
+        #expect(state.shouldPull == false)
+        #expect(state.shouldPush == false)
+    }
 }

--- a/GitClientTests/SyncStateTests.swift
+++ b/GitClientTests/SyncStateTests.swift
@@ -12,11 +12,11 @@ import Foundation
 @MainActor
 struct SyncStateTests {
     @Test func sync() async throws {
-        let branch = "_test-fixture"
-        try await Process.output(GitSwitch(directory: .testFixture!, branchName: branch))
+        let branchName = "_test-fixture"
+        try await Process.output(GitSwitch(directory: .testFixture!, branchName: branchName))
         let state = SyncState()
         state.folderURL = .testFixture!
-        state.branchName = branch
+        state.branch = .init(name: branchName, isCurrent: true)
         try await state.sync()
 
         #expect(state.shouldPull == false)
@@ -28,7 +28,7 @@ struct SyncStateTests {
         let _ = try? await Process.output(GitCheckoutB(directory: .testFixture!, newBranchName: branch, startPoint: "_test-fixture"))
         let state = SyncState()
         state.folderURL = .testFixture!
-        state.branchName = branch
+        state.branch = .init(name: branch, isCurrent: true)
         try await state.sync()
 
         #expect(state.shouldPull == false)
@@ -41,7 +41,7 @@ struct SyncStateTests {
         try await Process.output(GitRevert(directory: .testFixture!, commit: "head"))
         let state = SyncState()
         state.folderURL = .testFixture!
-        state.branchName = branch
+        state.branch = .init(name: branch, isCurrent: true)
         try await state.sync()
 
         #expect(state.shouldPull == false)
@@ -54,7 +54,7 @@ struct SyncStateTests {
         try await Process.output(GitCheckoutB(directory: .testFixture!, newBranchName: branch, startPoint: "_test-fixture"))
         let state = SyncState()
         state.folderURL = .testFixture!
-        state.branchName = branch
+        state.branch = .init(name: branch, isCurrent: true)
         try await state.sync()
 
         #expect(state.shouldPull == true)
@@ -66,7 +66,7 @@ struct SyncStateTests {
         try await Process.output(GitCheckout(directory: .testFixture!, commitHash: tag))
         let state = SyncState()
         state.folderURL = .testFixture!
-        state.branchName = try await Process.output(GitBranch(directory: .testFixture!)).current?.name
+        state.branch = try await Process.output(GitBranch(directory: .testFixture!)).current
         try await state.sync()
 
         #expect(state.shouldPull == false)

--- a/GitClientTests/SyncStateTests.swift
+++ b/GitClientTests/SyncStateTests.swift
@@ -11,7 +11,7 @@ import Foundation
 
 @MainActor
 struct SyncStateTests {
-    @Test func synced() async throws {
+    @Test func sync() async throws {
         let branch = "_test-fixture"
         try await Process.output(GitSwitch(directory: .testFixture!, branchName: branch))
         let state = SyncState()


### PR DESCRIPTION
This pull request includes several changes to the `GitClient` project, focusing on improving how branch information is handled and ensuring that detached HEAD states are correctly managed. The most important changes include refactoring the `Branch` struct, updating the `SyncState` class to use the modified `Branch` struct, and adjusting the relevant tests to accommodate these changes.

Improvements to branch handling:

* [`GitClient/Models/Branch.swift`](diffhunk://#diff-39f21f27fc8061bf62b5b12746b4fee8ab3fa1565b37205f0cc5b4e3e8cce53cR11-R26): Added a new `detachedPrefix` constant and an `isDetached` computed property to the `Branch` struct, improving the logic for determining if a branch is detached.

Updates to sync state:

* [`GitClient/Models/Observables/SyncState.swift`](diffhunk://#diff-b7046020180130d94a3749854481eb92fe44f6b7cf9d4f7ecae3371034189380L14-R33): Updated the `SyncState` class to use the `Branch` struct instead of a branch name string. This includes changes to the `sync` method to handle detached branches properly.
* [`GitClient/Views/Folder/FolderView.swift`](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eL178-R178): Modified the `FolderView` to set the `branch` property in `SyncState` instead of just the branch name.

Test adjustments:

* [`GitClientTests/SyncStateTests.swift`](diffhunk://#diff-5f484d754aa1985a14e65640789941aada7686802abaf00f50da1ea634f7d850L14-R19): Updated existing tests to use the `Branch` struct and added a new test to verify the behavior when syncing a detached HEAD state. [[1]](diffhunk://#diff-5f484d754aa1985a14e65640789941aada7686802abaf00f50da1ea634f7d850L14-R19) [[2]](diffhunk://#diff-5f484d754aa1985a14e65640789941aada7686802abaf00f50da1ea634f7d850L31-R31) [[3]](diffhunk://#diff-5f484d754aa1985a14e65640789941aada7686802abaf00f50da1ea634f7d850L44-R44) [[4]](diffhunk://#diff-5f484d754aa1985a14e65640789941aada7686802abaf00f50da1ea634f7d850L57-R74)