### PR TITLE
Update help text for revision range search in FolderView

### DIFF
--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -71,7 +71,7 @@ struct FolderView: View {
                 Text("Author: " + searchText).searchCompletion(SearchToken(kind: .author, text: searchText))
                     .help("Search commits by author matching the given pattern (regular expression).")
                 Text("Revision Range: " + searchText).searchCompletion(SearchToken(kind: .revisionRange, text: searchText))
-                    .help("Search commits within the revision range specified by Git syntax. e.g., main.., abc123..def456")
+                    .help("Search commits within the revision range specified by Git syntax. e.g., main.., v1.0.0...v2.0.0")
             }
         })
         .task {


### PR DESCRIPTION
Changed the help text for the revision range search from 'main.., abc123..def456' to 'main.., v1.0.0...v2.0.0' to provide a clearer example of Git syntax.