### PR TITLE
Enhance badge visibility with animations in FolderView

### DIFF
--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -416,9 +416,11 @@ struct FolderView: View {
         } label: {
             Image(systemName: "arrow.down")
                 .overlay(alignment: .topTrailing, content: {
-                    if syncState.shouldPull {
-                        badge()
-                    }
+                    badge()
+                        .animation(.default, body: { content in
+                            content
+                                .opacity(syncState.shouldPull ? 1 : 0)
+                        })
                 })
         }
         .help("Pull")
@@ -439,9 +441,11 @@ struct FolderView: View {
         } label: {
             Image(systemName: "arrow.up")
                 .overlay(alignment: .topTrailing, content: {
-                    if syncState.shouldPush {
                         badge()
-                    }
+                            .animation(.default, body: { content in
+                                content
+                                    .opacity(syncState.shouldPush ? 1 : 0)
+                            })
                 })
         }
         .help("Push origin HEAD")


### PR DESCRIPTION
This pull request includes changes to the `FolderView` in `GitClient/Views/Folder/FolderView.swift` to improve the visibility of the pull and push badges using animations.

Changes to badge visibility:

* [`GitClient/Views/Folder/FolderView.swift`](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eL419-R423): Replaced conditional badge rendering with an animation that adjusts the opacity of the badge based on `syncState.shouldPull`.
* [`GitClient/Views/Folder/FolderView.swift`](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eL442-R448): Replaced conditional badge rendering with an animation that adjusts the opacity of the badge based on `syncState.shouldPush`.