### PR TITLE
Fix git log parsing by dropping the last separator before splitting logs

### DIFF
--- a/GitClient/Models/Commands/GitLog.swift
+++ b/GitClient/Models/Commands/GitLog.swift
@@ -70,7 +70,8 @@ struct GitLog: Git {
 
     func parse(for stdOut: String) throws -> [Commit] {
         guard !stdOut.isEmpty else { return [] }
-        let logs = stdOut.components(separatedBy: String.componentSeparator + "\n")
+        let dropped = stdOut.dropLast(String.componentSeparator.count)
+        let logs = dropped.components(separatedBy: String.componentSeparator + "\n")
         return logs.map { log in
             let separated = log.components(separatedBy: String.formatSeparator)
             let refs: [String]

--- a/GitClient/Models/Commands/GitShow.swift
+++ b/GitClient/Models/Commands/GitShow.swift
@@ -50,7 +50,7 @@ struct GitShow: Git {
             branches: refs.filter { !$0.hasPrefix("tag: ") },
             tags: refs.filter { $0.hasPrefix("tag: ") }.map { String($0.dropFirst(5)) }
         )
-        print(commit)
+        
         return CommitDetail(
             commit: commit,
             diff: try Diff(raw: String(splits[safe: 1] ?? ""))


### PR DESCRIPTION
- Modified the `parse` function in `GitLog.swift` to drop the last separator from the `stdOut` string before splitting it into log entries.
- Removed unnecessary print statement in `GitShow.swift`.


Before
<img width="1070" alt="Screenshot 2025-04-23 at 11 25 14" src="https://github.com/user-attachments/assets/8f801b6a-b4e8-497c-965e-007a7726b62c" />

After
<img width="995" alt="Screenshot 2025-04-23 at 11 26 11" src="https://github.com/user-attachments/assets/6ff5ef79-135c-4a6b-9ba5-bbee666ff106" />
