### PR TITLE
Commits count

### DIFF
--- a/GitClient.xcodeproj/project.pbxproj
+++ b/GitClient.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		6186EBF92DA5ED4800DCC20E /* AmendCommitSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6186EBF82DA5ED4800DCC20E /* AmendCommitSheet.swift */; };
 		6193DDCD2DB8CA1400B156C4 /* CommitLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DDCC2DB8CA1400B156C4 /* CommitLogView.swift */; };
 		6193DDCF2DB8E18300B156C4 /* FolderViewShowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DDCE2DB8E18300B156C4 /* FolderViewShowing.swift */; };
+		6193DDD12DB9B08A00B156C4 /* GitRevListCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DDD02DB9B08200B156C4 /* GitRevListCount.swift */; };
 		619759462C89F1EC00E9CA4F /* GitRestorePatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619759452C89F1EC00E9CA4F /* GitRestorePatch.swift */; };
 		619759482C8A756F00E9CA4F /* GitStatusShort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619759472C8A756F00E9CA4F /* GitStatusShort.swift */; };
 		6197594A2C8A76DA00E9CA4F /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619759492C8A76DA00E9CA4F /* Status.swift */; };
@@ -200,6 +201,7 @@
 		6186EBF82DA5ED4800DCC20E /* AmendCommitSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmendCommitSheet.swift; sourceTree = "<group>"; };
 		6193DDCC2DB8CA1400B156C4 /* CommitLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitLogView.swift; sourceTree = "<group>"; };
 		6193DDCE2DB8E18300B156C4 /* FolderViewShowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderViewShowing.swift; sourceTree = "<group>"; };
+		6193DDD02DB9B08200B156C4 /* GitRevListCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRevListCount.swift; sourceTree = "<group>"; };
 		619759452C89F1EC00E9CA4F /* GitRestorePatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRestorePatch.swift; sourceTree = "<group>"; };
 		619759472C8A756F00E9CA4F /* GitStatusShort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusShort.swift; sourceTree = "<group>"; };
 		619759492C8A76DA00E9CA4F /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 				61702D0E2C9E8CAF00FE7E35 /* GitTagDelete.swift */,
 				61B5BBB82C9B9B250087A9F6 /* GitTagPointsAt.swift */,
 				61702D082C9E7FA100FE7E35 /* GitRevert.swift */,
+				6193DDD02DB9B08200B156C4 /* GitRevListCount.swift */,
 			);
 			path = Commands;
 			sourceTree = "<group>";
@@ -721,6 +724,7 @@
 				61B3C55E2CB4A74C00021B36 /* GitShow.swift in Sources */,
 				616C6FC92C97BC8200A419DE /* StashChangedContentView.swift in Sources */,
 				61D34C872CA91F620032A22A /* CommitMessageProperties.swift in Sources */,
+				6193DDD12DB9B08A00B156C4 /* GitRevListCount.swift in Sources */,
 				61FAF49E2C68DBFB000B7ACB /* GitCommitAmend.swift in Sources */,
 				61B3C5642CB93CE500021B36 /* CommitDetailStackView.swift in Sources */,
 				61EBD7D328E966190009ED92 /* GitSwitch.swift in Sources */,

--- a/GitClient/Models/Commands/GitRevListCount.swift
+++ b/GitClient/Models/Commands/GitRevListCount.swift
@@ -1,0 +1,27 @@
+//
+//  GitRevList.swift
+//  GitClient
+//
+//  Created by Makoto Aoyama on 2025/04/24.
+//
+
+import Foundation
+
+struct GitRevListCount: Git {
+    typealias OutputModel = Int?
+    var arguments: [String] {
+        var args = [
+            "git",
+            "rev-list",
+            "--count"
+        ]
+        args.append(commit)
+        return args
+    }
+    var directory: URL
+    var commit = "HEAD"
+
+    func parse(for stdOut: String) -> Int? {
+        Int(stdOut)
+    }
+}

--- a/GitClient/Models/Commands/GitRevListCount.swift
+++ b/GitClient/Models/Commands/GitRevListCount.swift
@@ -1,5 +1,5 @@
 //
-//  GitRevList.swift
+//  GitRevListCount.swift
 //  GitClient
 //
 //  Created by Makoto Aoyama on 2025/04/24.

--- a/GitClient/Models/Commands/GitRevListCount.swift
+++ b/GitClient/Models/Commands/GitRevListCount.swift
@@ -22,6 +22,6 @@ struct GitRevListCount: Git {
     var commit = "HEAD"
 
     func parse(for stdOut: String) -> Int? {
-        Int(stdOut)
+        Int(stdOut.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 }

--- a/GitClient/Models/Observables/LogStore.swift
+++ b/GitClient/Models/Observables/LogStore.swift
@@ -183,6 +183,7 @@ import Observation
         guard let directory else { return }
         totalCommitsCount = try await Process.output(GitLog(
             directory: directory,
+            revisionRange: searchTokenRevisionRange,
             grep: grep,
             grepAllMatch: grepAllMatch,
             s: s,

--- a/GitClient/Models/Observables/LogStore.swift
+++ b/GitClient/Models/Observables/LogStore.swift
@@ -77,6 +77,7 @@ import Observation
         }
     }
 
+    /// revisionRangeをSearchTokenで利用するための別メソッド
     private func loadCommitsWithSearchTokenRevisionRange(directory: URL, revisionRange: String) async throws -> [Commit] {
         try await Process.output(GitLog(
             directory: directory,
@@ -89,7 +90,7 @@ import Observation
         ))
     }
 
-    /// logsを全てを最新に更新しlogs.first以降のコミットを取得し追加(SearchTokennoRevisionRangeがない場合)
+    /// logsを全てを最新に更新しlogs.first以降のコミットを取得し追加(SearchTokenのRevisionRangeがない場合)
     func update() async {
         guard let directory else {
             notCommitted = nil

--- a/GitClient/Models/Observables/LogStore.swift
+++ b/GitClient/Models/Observables/LogStore.swift
@@ -181,14 +181,18 @@ import Observation
 
     private func loadTotalCommitsCount() async throws {
         guard let directory else { return }
-        totalCommitsCount = try await Process.output(GitLog(
-            directory: directory,
-            revisionRange: searchTokenRevisionRange,
-            grep: grep,
-            grepAllMatch: grepAllMatch,
-            s: s,
-            g: g,
-            author: author
-        )).count
+        if searchTokens.isEmpty {
+            totalCommitsCount = try await Process.output(GitRevListCount(directory: directory))
+        } else {
+            totalCommitsCount = try await Process.output(GitLog(
+                directory: directory,
+                revisionRange: searchTokenRevisionRange,
+                grep: grep,
+                grepAllMatch: grepAllMatch,
+                s: s,
+                g: g,
+                author: author
+            )).count
+        }
     }
 }

--- a/GitClient/Views/Folder/CommitLogView.swift
+++ b/GitClient/Views/Folder/CommitLogView.swift
@@ -22,6 +22,15 @@ struct CommitLogView: View {
                     await logStore.logViewTask(log)
                 }
         }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                Divider()
+                Text("1,000 Commits")
+                    .font(.callout)
+                    .padding(12)
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+        }
     }
 
     fileprivate func logsRow(_ log: Log) -> some View {

--- a/GitClient/Views/Folder/CommitLogView.swift
+++ b/GitClient/Views/Folder/CommitLogView.swift
@@ -25,11 +25,25 @@ struct CommitLogView: View {
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {
                 Divider()
-                Text("1,000 Commits")
+                countText()
                     .font(.callout)
                     .padding(12)
             }
             .background(Color(nsColor: .textBackgroundColor))
+        }
+    }
+
+    fileprivate func countText() -> some View {
+        if let count = logStore.totalCommitsCount {
+            let subText: String
+            if count == 1 {
+                subText = "Commit"
+            } else {
+                subText = "Commits"
+            }
+            return Text("\(count) \(subText)")
+        } else {
+            return Text("")
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new feature to display the total number of commits in the `CommitLogView` and includes the necessary backend and UI changes to support this functionality. The changes involve adding a new model for counting commits, updating the `LogStore` observable to calculate and store the count, and modifying the UI to display the count.

### Backend Changes:
* **Addition of `GitRevListCount` Command**:
  - A new struct `GitRevListCount` was added to execute the `git rev-list --count` command and parse its output to retrieve the total number of commits. (`GitClient/Models/Commands/GitRevListCount.swift`)
  - Updated the Xcode project file to include `GitRevListCount.swift` in the build sources. (`GitClient.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R65) [[2]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R204) [[3]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R531) [[4]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R727)

* **Enhancements to `LogStore` Observable**:
  - Added a `totalCommitsCount` property to store the count of commits. (`LogStore.swift`)
  - Implemented the `loadTotalCommitsCount` method to calculate the total commits count based on the current directory and search tokens. (`LogStore.swift`)
  - Updated methods like `logs()`, `update()`, and `removeAll()` to integrate the new `loadTotalCommitsCount` functionality. (`LogStore.swift`) [[1]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522R65) [[2]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522R77-R83) [[3]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522R130) [[4]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522R139)

### UI Changes:
* **Display Commit Count in `CommitLogView`**:
  - Modified `CommitLogView` to include a bottom inset displaying the total number of commits. This uses the `totalCommitsCount` property from `LogStore`. (`CommitLogView.swift`)