### PR TITLE
Add progress view to tag sheet

### DIFF
--- a/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
+++ b/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
@@ -60,7 +60,7 @@ struct CreateNewTagSheet: View {
                     if isLoading {
                         ProgressView()
                             .scaleEffect(0.4)
-                            .frame(width: 29, height: 17)
+                            .frame(width: 102, height: 17)
                     } else {
                         Button("Create & Push") {
                             Task {

--- a/GitClient/Views/Tags/TagsContentView.swift
+++ b/GitClient/Views/Tags/TagsContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct TagsContentView: View {
     var folder: Folder
     @Binding var showingTags: Bool
-    var tags: [String]?
+    @Binding var tags: [String]?
     private var filteredTags: [String]? {
         guard !filterText.isEmpty else { return tags }
         return tags?.filter { $0.lowercased().contains(filterText.lowercased()) }
@@ -46,7 +46,7 @@ struct TagsContentView: View {
                                     Task {
                                         do {
                                             try await Process.output(GitTagDelete(directory: folder.url, tagname: tag))
-                                            showingTags = false
+                                            tags = tags?.filter{ $0 != tag}
                                         } catch {
                                             self.error = error
                                         }
@@ -74,12 +74,16 @@ struct TagsContentView: View {
 
 #Preview {
     @Previewable @State var showingTags = false
-    TagsContentView(folder: .init(url: URL(string: "file:///maoyama/Projects/")!), showingTags: $showingTags, tags: ["v1.0.0", "v1.1.0", "v2.0.0"])
+    @Previewable @State var tags: [String]? = ["v1.0.0", "v1.1.0", "v2.0.0"]
+
+    TagsContentView(folder: .init(url: URL(string: "file:///maoyama/Projects/")!), showingTags: $showingTags, tags: $tags)
         .frame(width: 300, height: 660)
 }
 
 #Preview("No Content") {
     @Previewable @State var showingTags = false
-    TagsContentView(folder: .init(url: URL(string: "file:///maoyama/Projects/")!), showingTags: $showingTags, tags: [])
+    @Previewable @State var tags: [String]? = []
+
+    TagsContentView(folder: .init(url: URL(string: "file:///maoyama/Projects/")!), showingTags: $showingTags, tags: $tags)
         .frame(width: 300, height: 660)
 }

--- a/GitClient/Views/Tags/TagsView.swift
+++ b/GitClient/Views/Tags/TagsView.swift
@@ -15,7 +15,7 @@ struct TagsView: View {
     @State private var error: Error?
 
     var body: some View {
-        TagsContentView(folder: folder, showingTags: $showingTags, tags: tags)
+        TagsContentView(folder: folder, showingTags: $showingTags, tags: $tags)
             .frame(width: 300, height: 660)
             .task {
                 do {


### PR DESCRIPTION
This pull request introduces enhancements to the `CreateNewTagSheet` and `TagsContentView` components in the `GitClient` project. The changes focus on improving user experience by adding loading indicators during tag creation and ensuring the tags list updates dynamically when tags are deleted.

### Enhancements to `CreateNewTagSheet`:

* Added a loading state (`isLoading`) to show a `ProgressView` while a new tag is being created and pushed. The loading state is toggled appropriately during the process to provide feedback to the user. [[1]](diffhunk://#diff-95e25c5770961d64788087b479f773c195689f2a63fe15d8900f4203c661a748R15) [[2]](diffhunk://#diff-95e25c5770961d64788087b479f773c195689f2a63fe15d8900f4203c661a748R60-R67) [[3]](diffhunk://#diff-95e25c5770961d64788087b479f773c195689f2a63fe15d8900f4203c661a748R79-R91)

### Improvements to `TagsContentView`:

* Changed the `tags` property from `var` to `@Binding` to allow dynamic updates to the tags list.
* Updated the tag deletion logic to remove the deleted tag from the list immediately, ensuring the UI reflects the change without requiring a refresh.
* Adjusted the previews to reflect the new `@Binding` property for `tags`.

### Update to `TagsView`:

* Updated the `TagsView` to pass the `tags` property as a binding to `TagsContentView`, ensuring consistency with the new `@Binding` implementation.