### PR TITLE
Add errorSheet that scrollable error text

### DIFF
--- a/GitClient.xcodeproj/project.pbxproj
+++ b/GitClient.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		616C6FC62C96E3D100A419DE /* StashChangedDetailContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C6FC52C96E3D100A419DE /* StashChangedDetailContentView.swift */; };
 		616C6FC92C97BC8200A419DE /* StashChangedContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C6FC82C97BC8200A419DE /* StashChangedContentView.swift */; };
 		616C6FCC2C97C3CC00A419DE /* GitStashApply.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C6FCB2C97C3CC00A419DE /* GitStashApply.swift */; };
+		616CFE7A2DBB02E100CAFCE6 /* ErrorTextSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CFE792DBB02E100CAFCE6 /* ErrorTextSheet.swift */; };
 		61702D092C9E7FA100FE7E35 /* GitRevert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61702D082C9E7FA100FE7E35 /* GitRevert.swift */; };
 		61702D0B2C9E8A1B00FE7E35 /* GitTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61702D0A2C9E8A1600FE7E35 /* GitTag.swift */; };
 		61702D0D2C9E8BFF00FE7E35 /* GitTagCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61702D0C2C9E8BF900FE7E35 /* GitTagCreate.swift */; };
@@ -181,6 +182,7 @@
 		616C6FC52C96E3D100A419DE /* StashChangedDetailContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashChangedDetailContentView.swift; sourceTree = "<group>"; };
 		616C6FC82C97BC8200A419DE /* StashChangedContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashChangedContentView.swift; sourceTree = "<group>"; };
 		616C6FCB2C97C3CC00A419DE /* GitStashApply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStashApply.swift; sourceTree = "<group>"; };
+		616CFE792DBB02E100CAFCE6 /* ErrorTextSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTextSheet.swift; sourceTree = "<group>"; };
 		61702D082C9E7FA100FE7E35 /* GitRevert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRevert.swift; sourceTree = "<group>"; };
 		61702D0A2C9E8A1600FE7E35 /* GitTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTag.swift; sourceTree = "<group>"; };
 		61702D0C2C9E8BF900FE7E35 /* GitTagCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTagCreate.swift; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 				61F5B7AB2CBA1978005C736E /* Commit */,
 				6199ED3B2DA7403300D916EE /* Folder */,
 				61347EEF28D5D16C00625FC4 /* ContentView.swift */,
+				616CFE792DBB02E100CAFCE6 /* ErrorTextSheet.swift */,
 				6180C0A728E916B900B3AEAD /* BranchesView.swift */,
 				619DA6922CA62A1000E58DF9 /* SettingsView.swift */,
 			);
@@ -754,6 +757,7 @@
 				610134BF2C718E760071677C /* GitSwitchDetach.swift in Sources */,
 				616C4C1C28E88828000E7154 /* GitCommit.swift in Sources */,
 				616C6FC22C96C3B500A419DE /* GitStashDrop.swift in Sources */,
+				616CFE7A2DBB02E100CAFCE6 /* ErrorTextSheet.swift in Sources */,
 				6197594C2C8BE95900E9CA4F /* StagedView.swift in Sources */,
 				61E290D128E1DA2E00BCEB04 /* String+.swift in Sources */,
 				61326BBC2BC27A3300472D64 /* Diff.swift in Sources */,

--- a/GitClient/GitClientApp.swift
+++ b/GitClient/GitClientApp.swift
@@ -15,7 +15,7 @@ struct GitClientApp: App {
         WindowGroup {
             ContentView()
                 .environment(\.openAIAPISecretKey, keychainStorage.openAIAPISecretKey)
-                .errorAlert($keychainStorage.error)
+                .errorSheet($keychainStorage.error)
         }
         Settings {
             SettingsView(openAIAPISecretKey: $keychainStorage.openAIAPISecretKey)

--- a/GitClient/Views/BranchesView.swift
+++ b/GitClient/Views/BranchesView.swift
@@ -114,7 +114,7 @@ struct BranchesView: View {
                 self.error = error
             }
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }
 

--- a/GitClient/Views/Commit/CommitCreateView.swift
+++ b/GitClient/Views/Commit/CommitCreateView.swift
@@ -310,7 +310,7 @@ struct CommitCreateView: View {
                 self.error = error
             }
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 
     private func updateChanges() async {

--- a/GitClient/Views/Commit/CommitDetailContentView.swift
+++ b/GitClient/Views/Commit/CommitDetailContentView.swift
@@ -158,6 +158,6 @@ struct CommitDetailContentView: View {
                 shortstat = (try? await Process.output(GitShowShortstat(directory: folder.url, object: commit.hash))) ?? ""
             }
         })
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }

--- a/GitClient/Views/Commit/CommitDetailView.swift
+++ b/GitClient/Views/Commit/CommitDetailView.swift
@@ -28,6 +28,6 @@ struct CommitDetailView: View {
                 self.error = error
             }
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }

--- a/GitClient/Views/Commit/CommitMessageSnippetView.swift
+++ b/GitClient/Views/Commit/CommitMessageSnippetView.swift
@@ -83,7 +83,7 @@ struct CommitMessageSnippetView: View {
             .frame(height: 80)
             .background(Color(NSColor.textBackgroundColor))
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }
 

--- a/GitClient/Views/Commit/CommitMessageSuggestionView.swift
+++ b/GitClient/Views/Commit/CommitMessageSuggestionView.swift
@@ -46,7 +46,7 @@ struct CommitMessageSuggestionView: View {
                 Image(systemName: "list.dash")
             })
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }
 

--- a/GitClient/Views/Commit/MergeCommitContentView.swift
+++ b/GitClient/Views/Commit/MergeCommitContentView.swift
@@ -57,7 +57,7 @@ struct MergeCommitContentView: View {
                 }
             }
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }
 

--- a/GitClient/Views/ContentView.swift
+++ b/GitClient/Views/ContentView.swift
@@ -109,7 +109,7 @@ struct ContentView: View {
         .onChange(of: selectionFolder, {
             selectionLog = nil
         })
-        .errorAlert($error)
+        .errorSheet($error)
         .environment(\.folder, selectionFolderURL)
     }
 }

--- a/GitClient/Views/ErrorTextSheet.swift
+++ b/GitClient/Views/ErrorTextSheet.swift
@@ -1,0 +1,52 @@
+//
+//  ErrorTextSheet.swift
+//  GitClient
+//
+//  Created by Makoto Aoyama on 2025/04/25.
+//
+
+import SwiftUI
+
+struct ErrorTextSheet: View {
+    @Binding var error: Error?
+
+    var body: some View {
+        VStack {
+            Text("Error")
+                .font(.headline)
+            ScrollView {
+                HStack(spacing: 0) {
+                    Text(error?.localizedDescription ?? "")
+                        .textSelection(.enabled)
+                    Spacer(minLength: 0)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("OK") {
+                    error = nil
+                }
+            }
+        }
+        .padding()
+        .cornerRadius(8)
+        .frame(width: 480, height: 240)
+        .background(Color(NSColor.textBackgroundColor))
+    }
+}
+
+#Preview {
+    @Previewable @State var error: Error? = ProcessError(description: "Hello")
+
+    ErrorTextSheet(error: $error)
+}
+
+#Preview {
+    @Previewable @State var error: Error? = ProcessError(description: """
+Swift’s enumerations are well suited to represent simple errors. Create an enumeration that conforms to the Error protocol with a case for each possible error. If there are additional details about the error that could be helpful for recovery, use associated values to include that information.
+The following example shows an IntParsingError enumeration that captures two different kinds of errors that can occur when parsing an integer from a string: overflow, where the value represented by the string is too large for the integer data type, and invalid input, where nonnumeric characters are found within the input.
+""")
+
+    ErrorTextSheet(error: $error)
+}

--- a/GitClient/Views/Extensions/View+.swift
+++ b/GitClient/Views/Extensions/View+.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension View {
-    func errorAlert(_ error: Binding<Error?>) -> some View {
+    func errorSheet(_ error: Binding<Error?>) -> some View {
         sheet(isPresented: .constant(error.wrappedValue != nil)) {
             ErrorTextSheet(error: error)
         }

--- a/GitClient/Views/Extensions/View+.swift
+++ b/GitClient/Views/Extensions/View+.swift
@@ -9,12 +9,8 @@ import SwiftUI
 
 extension View {
     func errorAlert(_ error: Binding<Error?>) -> some View {
-        alert(
-            error.wrappedValue?.localizedDescription ?? "",
-            isPresented: .constant(error.wrappedValue != nil)) {
-            Button("OK", role: .cancel) {
-                error.wrappedValue = nil
-            }
+        sheet(isPresented: .constant(error.wrappedValue != nil)) {
+            ErrorTextSheet(error: error)
         }
     }
 }

--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -126,8 +126,8 @@ struct FolderView: View {
                 }
             }
         })
-        .errorAlert($error)
-        .errorAlert($logStore.error)
+        .errorSheet($error)
+        .errorSheet($logStore.error)
         .sheet(item: $showing.createNewBranchFrom, content: { _ in
             CreateNewBranchSheet(folder: folder, showingCreateNewBranchFrom: $showing.createNewBranchFrom) {
                 Task {

--- a/GitClient/Views/Folder/Sheets/AmendCommitSheet.swift
+++ b/GitClient/Views/Folder/Sheets/AmendCommitSheet.swift
@@ -56,6 +56,6 @@ struct AmendCommitSheet: View {
         .task {
             message = showingAmendCommitAt?.rawBody ?? ""
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }

--- a/GitClient/Views/Folder/Sheets/CreateNewBranchSheet.swift
+++ b/GitClient/Views/Folder/Sheets/CreateNewBranchSheet.swift
@@ -60,7 +60,7 @@ struct CreateNewBranchSheet: View {
         }
         .padding()
         .cornerRadius(8)
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }
 

--- a/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
+++ b/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
@@ -96,6 +96,6 @@ struct CreateNewTagSheet: View {
         }
         .padding()
         .cornerRadius(8)
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }

--- a/GitClient/Views/Folder/Sheets/RenameBranchSheet.swift
+++ b/GitClient/Views/Folder/Sheets/RenameBranchSheet.swift
@@ -59,6 +59,6 @@ struct RenameBranchSheet: View {
         }
         .padding()
         .cornerRadius(8)
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }

--- a/GitClient/Views/StashChanged/StashChangedContentView.swift
+++ b/GitClient/Views/StashChanged/StashChangedContentView.swift
@@ -88,7 +88,7 @@ struct StashChangedContentView: View {
             }
         })
         .frame(minWidth: 800, minHeight: 700)
-        .errorAlert($error)
+        .errorSheet($error)
     }
 
     private func updateDiff() async {

--- a/GitClient/Views/StashChanged/StashChangedView.swift
+++ b/GitClient/Views/StashChanged/StashChangedView.swift
@@ -31,6 +31,6 @@ struct StashChangedView: View {
                 self.error = error
             }
         }
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }

--- a/GitClient/Views/Tags/TagsContentView.swift
+++ b/GitClient/Views/Tags/TagsContentView.swift
@@ -68,7 +68,7 @@ struct TagsContentView: View {
             }
         }
         .scrollContentBackground(.hidden)
-        .errorAlert($error)
+        .errorSheet($error)
     }
 }
 

--- a/GitClient/Views/Tags/TagsView.swift
+++ b/GitClient/Views/Tags/TagsView.swift
@@ -24,6 +24,6 @@ struct TagsView: View {
                     self.error = error
                 }
             }
-            .errorAlert($error)
+            .errorSheet($error)
     }
 }


### PR DESCRIPTION

<img width="533" alt="Screenshot 2025-04-25 at 20 37 17" src="https://github.com/user-attachments/assets/90cfe28b-b70f-4039-9626-9d20fcae94d8" />



This pull request introduces a new error handling mechanism by replacing `errorAlert` with `errorSheet` across the codebase, alongside the addition of a new `ErrorTextSheet` component. It also updates the project configuration to include the new `ErrorTextSheet.swift` file.

### Error Handling Updates:
* Replaced `errorAlert` with `errorSheet` in various views, including `ContentView`, `BranchesView`, `CommitCreateView`, `FolderView`, and more. This change enables the use of a sheet-based error display instead of alerts for a more consistent user experience. [[1]](diffhunk://#diff-f23089e434676cc7ba12885385e1cd7c2082a49ec00011533cdddbef82736bedL18-R18) [[2]](diffhunk://#diff-ba4ac997265ae40296eb9e4f5bf03d398178ccc912c4f16a785cc76de0d6fe6aL117-R117) [[3]](diffhunk://#diff-cea1c981e2a501dd4aeb9b014220c616422ce8feaceda56e6e4f6c0682f5dfc0L313-R313) [[4]](diffhunk://#diff-7c23e0932cd90b6072f70acc6ed6eb514b0ad4ec63a1dfc83d738cd241f9392eL129-R130) and others)
* Added a new `ErrorTextSheet` component to display error messages in a sheet with support for text selection and a dismiss button.
* Updated the `View` extension to include the new `errorSheet` method, which uses `ErrorTextSheet` for error handling.

### Project Configuration Updates:
* Added `ErrorTextSheet.swift` to the project files in `GitClient.xcodeproj/project.pbxproj` to ensure it is included in the build process. [[1]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R46) [[2]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R185) [[3]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R447) [[4]](diffhunk://#diff-80b2af6b5d478da051ecbc80fe93949da2de45b06e17633a4082926c0f385177R760)