### PR TITLE
Fix commit graph rendering logic

### DIFF
--- a/GitClient/Views/Folder/CommitGraph.swift
+++ b/GitClient/Views/Folder/CommitGraph.swift
@@ -42,6 +42,7 @@ struct CommitGraph {
                     }
                     result.append(positioned)
                     children.forEach { child in
+                        // parentHashesが1でない時はマージコミットであり、別の親がカラムをまだ利用するため
                         if child.column != positioned.column && child.commit.parentHashes.count == 1 {
                             if let index = usingColumns.firstIndex(where: { $0 == child.column }) {
                                 usingColumns.remove(at: index)

--- a/GitClient/Views/Folder/CommitGraph.swift
+++ b/GitClient/Views/Folder/CommitGraph.swift
@@ -42,7 +42,7 @@ struct CommitGraph {
                     }
                     result.append(positioned)
                     children.forEach { child in
-                        if child.column != positioned.column {
+                        if child.column != positioned.column && child.commit.parentHashes.count == 1 {
                             if let index = usingColumns.firstIndex(where: { $0 == child.column }) {
                                 usingColumns.remove(at: index)
                             }


### PR DESCRIPTION
Before
<img width="1224" alt="Screenshot 2025-05-01 at 23 14 40" src="https://github.com/user-attachments/assets/7219e22a-4748-4d33-b75e-33fdaf528f2b" />
After
<img width="1224" alt="Screenshot 2025-05-01 at 23 13 35" src="https://github.com/user-attachments/assets/3db62898-233a-469c-b13f-70bf2839e03c" />
