### PR TITLE
Update CommitGraph view colors

### DIFF
--- a/GitClient/Views/Folder/CommitGraph.swift
+++ b/GitClient/Views/Folder/CommitGraph.swift
@@ -221,7 +221,7 @@ struct GraphNode: View {
     @Binding var selectionLogID: String?
     private var fillColor: Color {
         if logID == selectionLogID {
-            return Color.blue
+            return Color.accentColor
         }
         if logID == Log.notCommitted.id {
             return Color.secondary

--- a/GitClient/Views/Folder/CommitGraph.swift
+++ b/GitClient/Views/Folder/CommitGraph.swift
@@ -250,14 +250,6 @@ struct GraphNodeText: View {
     var logID: String
     var title: String
     @Binding var selectionLogID: String?
-    var textColor: Color {
-        if logID == selectionLogID {
-            return Color.white
-        } else {
-            return Color.secondary
-        }
-    }
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack {
@@ -266,7 +258,7 @@ struct GraphNodeText: View {
                 .padding(.vertical, 4)
         }
             .font(.callout)
-            .foregroundStyle(textColor)
+            .foregroundStyle(logID == selectionLogID ? .white : .secondary)
             .background {
                 if logID == selectionLogID {
                     RoundedRectangle(cornerRadius: 4)

--- a/GitClient/Views/Folder/CommitGraph.swift
+++ b/GitClient/Views/Folder/CommitGraph.swift
@@ -250,6 +250,17 @@ struct GraphNodeText: View {
     var logID: String
     var title: String
     @Binding var selectionLogID: String?
+    var textColor: Color {
+        if logID == selectionLogID {
+            if colorScheme == .light {
+                return Color(nsColor: .textBackgroundColor)
+            }
+            return Color.primary
+        } else {
+            return Color.secondary
+        }
+    }
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack {
@@ -258,7 +269,7 @@ struct GraphNodeText: View {
                 .padding(.vertical, 4)
         }
             .font(.callout)
-            .foregroundStyle(logID == selectionLogID ? Color(nsColor: .textBackgroundColor) : .secondary)
+            .foregroundStyle(textColor)
             .background {
                 if logID == selectionLogID {
                     RoundedRectangle(cornerRadius: 4)

--- a/GitClient/Views/Folder/CommitGraph.swift
+++ b/GitClient/Views/Folder/CommitGraph.swift
@@ -252,10 +252,7 @@ struct GraphNodeText: View {
     @Binding var selectionLogID: String?
     var textColor: Color {
         if logID == selectionLogID {
-            if colorScheme == .light {
-                return Color(nsColor: .textBackgroundColor)
-            }
-            return Color.primary
+            return Color.white
         } else {
             return Color.secondary
         }


### PR DESCRIPTION
This pull request updates the `CommitGraph` UI in the `GitClient` to enhance visual consistency and improve readability. Key changes include updating color logic for selected nodes and introducing a new `textColor` property for `GraphNodeText`.

### Visual updates for `CommitGraph`:

* Updated the `fillColor` logic in `GraphNode` to use `Color.accentColor` for selected nodes instead of `Color.blue`, aligning with the app's accent color.
* Added a `textColor` property to `GraphNodeText` to dynamically determine the text color based on selection status, improving readability.
* Replaced the hardcoded `foregroundStyle` logic in `GraphNodeText` with the new `textColor` property for cleaner and more maintainable code.