### PR TITLE
Update footer style

### DIFF
--- a/GitClient/Views/Commit/CommitCreateView.swift
+++ b/GitClient/Views/Commit/CommitCreateView.swift
@@ -198,11 +198,11 @@ struct CommitCreateView: View {
             .layoutPriority(1)
             .background(Color(NSColor.textBackgroundColor))
             Divider()
-            HStack(spacing: 0) {
-                VStack(spacing: 2) {
+            HStack(alignment: .bottom,spacing: 0) {
+                VStack(spacing: 0) {
                     ZStack {
                             TextEditor(text: $commitMessage)
-                                .padding(.top, 12)
+                                .padding(.top, 16)
                                 .padding(.horizontal, 12)
                             if commitMessage.isEmpty {
                                 Label("Enter commit message here", systemImage: "plus.bubble")
@@ -210,7 +210,6 @@ struct CommitCreateView: View {
                                     .allowsHitTesting(false)
                             }
                     }
-                    .frame(height: 80)
                     HStack(spacing: 0) {
                         CommitMessageSuggestionView()
                         Button {

--- a/GitClient/Views/Commit/CommitCreateView.swift
+++ b/GitClient/Views/Commit/CommitCreateView.swift
@@ -198,7 +198,7 @@ struct CommitCreateView: View {
             .layoutPriority(1)
             .background(Color(NSColor.textBackgroundColor))
             Divider()
-            HStack(alignment: .bottom,spacing: 0) {
+            HStack(alignment: .bottom, spacing: 0) {
                 VStack(spacing: 0) {
                     ZStack {
                             TextEditor(text: $commitMessage)

--- a/GitClient/Views/Commit/CommitMessageSuggestionView.swift
+++ b/GitClient/Views/Commit/CommitMessageSuggestionView.swift
@@ -37,9 +37,10 @@ struct CommitMessageSuggestionView: View {
                         }
                     }
                 }
-                .padding(.leading)
+                .font(.callout)
+                .padding(.leading, 12)
             }
-            .frame(height: 44)
+            .frame(height: 40)
             Button(action: {
                 openWindow(id: WindowID.commitMessageSnippets.rawValue)
             }, label: {

--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -64,14 +64,17 @@ struct FolderView: View {
             }
             .background(Color(nsColor: .textBackgroundColor))
             .overlay(alignment: .trailing) {
-                Image(systemName: showGraph ? "g.circle.fill" : "g.circle")
-                    .font(.title3)
-                    .foregroundStyle( showGraph ? Color.accentColor : Color.secondary)
-                    .padding(.horizontal)
-                    .onTapGesture {
-                        showGraph.toggle()
-                    }
-                    .help("Commit Graph")
+                Button(action: {
+                    showGraph.toggle()
+                }) {
+                    Image(systemName: showGraph ? "point.3.filled.connected.trianglepath.dotted" : "point.3.connected.trianglepath.dotted")
+                        .font(.title3)
+                        .rotationEffect(.init(degrees: 270))
+                        .foregroundStyle( showGraph ? Color.accentColor : Color.secondary)
+                }
+                .buttonStyle(.accessoryBar)
+                .padding(.horizontal, 8)
+                .help("Commit Graph")
             }
         }
         .overlay(content: {


### PR DESCRIPTION
This pull request includes UI refinements and interaction improvements in the `CommitCreateView`, `CommitMessageSuggestionView`, and `FolderView` components of the GitClient. The changes focus on improving layout consistency, enhancing user experience, and updating visual elements.

### UI Refinements and Layout Adjustments:

* **`CommitCreateView.swift`:** Adjusted the alignment and spacing in the `HStack` containing the commit message editor. Increased the top padding of the `TextEditor` to improve visual spacing.
* **`CommitMessageSuggestionView.swift`:** Updated the font to `.callout` for better readability and adjusted the left padding to `12`. Reduced the frame height from `44` to `40` for a more compact design.

### Interaction Improvements:

* **`FolderView.swift`:** Replaced the static `Image` with a `Button` to toggle the commit graph view. Updated the icon to a more descriptive system image and added a rotation effect for better visual feedback. Applied a `.buttonStyle(.accessoryBar)` for consistency with other UI elements.