### PR TITLE
Fix capitalization in help text 

### DIFF
--- a/GitClient/Views/Commit/StagedView.swift
+++ b/GitClient/Views/Commit/StagedView.swift
@@ -28,7 +28,7 @@ struct StagedView: View {
                 StagedFileDiffView(
                     expandableFileDiffs: $fileDiffs,
                     selectButtonImageSystemName: "minus.circle",
-                    selectButtonHelp: "Unstage this hunk",
+                    selectButtonHelp: "Unstage This Hunk",
                     onSelectFileDiff: onSelectFileDiff,
                     onSelectChunk: onSelectChunk
                 )

--- a/GitClient/Views/Commit/UnstagedView.swift
+++ b/GitClient/Views/Commit/UnstagedView.swift
@@ -31,7 +31,7 @@ struct UnstagedView: View {
                 StagedFileDiffView(
                     expandableFileDiffs: $fileDiffs,
                     selectButtonImageSystemName: "plus.circle",
-                    selectButtonHelp: "Stage this hunk",
+                    selectButtonHelp: "Stage This Hunk",
                     onSelectFileDiff: onSelectFileDiff,
                     onSelectChunk: onSelectChunk
                 )
@@ -55,7 +55,7 @@ struct UnstagedView: View {
                                     Image(systemName: "plus.circle")
                                 }
                                 .buttonStyle(.accessoryBar)
-                                .help("Stage this file")
+                                .help("Stage This File")
                                 .padding(.horizontal)
                             }
                         }


### PR DESCRIPTION
This pull request makes minor text capitalization adjustments to user-facing strings in the `StagedView` and `UnstagedView` components to ensure consistency in UI text.

Text capitalization updates:

* [`GitClient/Views/Commit/StagedView.swift`](diffhunk://#diff-0f2e894fd31e75acbaae6c2533c96f42d28088ab9ce472eb7b2b8c2d7b0a1f92L31-R31): Updated the help text for the "Unstage this hunk" button to "Unstage This Hunk" for consistency.
* [`GitClient/Views/Commit/UnstagedView.swift`](diffhunk://#diff-57925e099d15a927910aeeb779a3f83d0544c6cc622eeecd59e1cfb799b6e306L34-R34): Updated the help text for the "Stage this hunk" button to "Stage This Hunk" for consistency.
* [`GitClient/Views/Commit/UnstagedView.swift`](diffhunk://#diff-57925e099d15a927910aeeb779a3f83d0544c6cc622eeecd59e1cfb799b6e306L58-R58): Updated the help text for the "Stage this file" button to "Stage This File" for consistency.…iles.