### PR TITLE
Update tagging behavior

### DIFF
--- a/GitClient/Views/Extensions/View+.swift
+++ b/GitClient/Views/Extensions/View+.swift
@@ -47,9 +47,6 @@ extension View {
                     }
                 }
             }
-            Button("Tag") {
-                showing.wrappedValue.createNewTagAt = commit
-            }
             if commit == logStore.commits.first {
                 if let notCommitted = logStore.notCommitted {
                     if notCommitted.diffCached.isEmpty {
@@ -62,6 +59,9 @@ extension View {
                         showing.wrappedValue.amendCommitAt = commit
                     }
                 }
+            }
+            Button("Tag") {
+                showing.wrappedValue.createNewTagAt = commit
             }
         }
     }

--- a/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
+++ b/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
@@ -77,7 +77,6 @@ struct CreateNewTagSheet: View {
                                     try await Process.output(
                                         GitPush(directory: folder.url, refspec: newTagname)
                                     )
-                                    isLoading = false
                                     onCreate()
                                     showingCreateNewTagAt = nil
                                 } catch {

--- a/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
+++ b/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
@@ -31,6 +31,7 @@ struct CreateNewTagSheet: View {
                             .textSelection(.enabled)
                             .padding(.horizontal, 4)
                         TextField("New tag name", text: $newTagname)
+                            .disabled(isLoading)
                     }
                 }
 


### PR DESCRIPTION
This pull request makes adjustments to the tagging functionality in the Git client, focusing on improving the user experience and fixing a minor issue in the `CreateNewTagSheet` view. The most important changes include moving the "Tag" button within the `View` extension and refining the behavior of the tag creation process.

### Tagging functionality adjustments:

* **Relocation of "Tag" button:**
  - The "Tag" button was removed and then re-added in a different position within the `View` extension in `GitClient/Views/Extensions/View+.swift`. This change likely improves the logical flow or layout of the UI. [[1]](diffhunk://#diff-0770ad72971e1d006cbd3e914a9e44c5421869064ebd56b269ce5c3d9f41fa90L50-L52) [[2]](diffhunk://#diff-0770ad72971e1d006cbd3e914a9e44c5421869064ebd56b269ce5c3d9f41fa90R63-R65)

### Tag creation improvements:

* **Disable text field during loading:**
  - The `TextField` for entering a new tag name in `CreateNewTagSheet` is now disabled while the `isLoading` state is active, preventing user interaction during the loading process.

* **Simplified loading state handling:**
  - The `isLoading` flag is no longer explicitly set to `false` after the tag creation process completes, as this may now be handled elsewhere or deemed unnecessary.