### PR TITLE
Improves hangs in commit graph view

### DIFF
--- a/GitClient/Models/Observables/LogStore.swift
+++ b/GitClient/Models/Observables/LogStore.swift
@@ -10,7 +10,7 @@ import Observation
 
 @MainActor
 @Observable class LogStore {
-    var number = 500
+    var number = 100
     var directory: URL?
     private var grep: [String] {
         searchTokens.filter { token in


### PR DESCRIPTION
The initial display of the commit graph and hang when selecting the commit graph.

Previously, 500 commits were displayed for the first time, but it will be improved to 100 commits.When displaying 500 commits.
<img width="1251" alt="Screenshot 2025-05-24 at 20 51 47" src="https://github.com/user-attachments/assets/765ee7a2-f184-40f9-9c1f-cb22b38b5306" />
(When you select the node of the commit graph)
<img width="1432" alt="Screenshot 2025-05-24 at 20 51 56" src="https://github.com/user-attachments/assets/948caea3-d611-4ff1-ab6d-25113e909483" />

200 commits
<img width="926" alt="Screenshot 2025-05-24 at 20 53 41" src="https://github.com/user-attachments/assets/012fc09d-ed6e-48f6-a207-707954c520bf" />
<img width="908" alt="Screenshot 2025-05-24 at 20 53 55" src="https://github.com/user-attachments/assets/0779490d-26a4-4895-b28f-1e9c58ceccf9" />

100 commits
<img width="960" alt="Screenshot 2025-05-24 at 20 59 37" src="https://github.com/user-attachments/assets/b52ef590-92d4-4d2b-9b37-d3ca86acda36" />
<img width="979" alt="Screenshot 2025-05-24 at 20 59 46" src="https://github.com/user-attachments/assets/65585cd2-9e61-48a7-ae88-1abac10735a0" />
