### PR TITLE
Shortstat footer

### DIFF
--- a/GitClient/Views/Commit/CommitDetailContentView.swift
+++ b/GitClient/Views/Commit/CommitDetailContentView.swift
@@ -137,6 +137,22 @@ struct CommitDetailContentView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color(NSColor.textBackgroundColor))
         .textSelection(.enabled)
+        .safeAreaInset(edge: .bottom, spacing: 0, content: {
+            VStack(spacing: 0) {
+                Divider()
+                Spacer()
+                HStack {
+                    Text(shortstat)
+                        .minimumScaleFactor(0.3)
+                        .foregroundStyle(.primary)
+                }
+                .font(.callout)
+
+                Spacer()
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+            .frame(height: 40)
+        })
         .onChange(of: commit, initial: true, { _, commit in
             Task {
                 do {

--- a/GitClient/Views/Commit/CommitDetailContentView.swift
+++ b/GitClient/Views/Commit/CommitDetailContentView.swift
@@ -120,9 +120,6 @@ struct CommitDetailContentView: View {
                     .foregroundStyle(.secondary)
                     Divider()
                         .padding(.top)
-                    Text(shortstat)
-                        .padding(.vertical, 6)
-                    Divider()
                     if commit.parentHashes.count == 2 {
                         MergeCommitContentView(mergeCommit: commit, directoryURL: folder.url)
                     } else {

--- a/GitClient/Views/Commit/CommitDetailContentView.swift
+++ b/GitClient/Views/Commit/CommitDetailContentView.swift
@@ -144,7 +144,6 @@ struct CommitDetailContentView: View {
                         .foregroundStyle(.primary)
                 }
                 .font(.callout)
-
                 Spacer()
             }
             .background(Color(nsColor: .textBackgroundColor))

--- a/GitClient/Views/Commit/DiffView.swift
+++ b/GitClient/Views/Commit/DiffView.swift
@@ -15,7 +15,7 @@ struct DiffView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             DiffTabView(tab: $tab)
-                .padding(.vertical)
+                .padding(.top)
             if tab == 0 {
                 DiffCommitListView(commits: commits)
                     .padding(.vertical)


### PR DESCRIPTION
This pull request makes UI adjustments to improve the layout and user experience in the `CommitDetailContentView` and `DiffView` components. The most notable changes involve repositioning the `shortstat` text in `CommitDetailContentView` and refining padding in `DiffView`.

### Changes to `CommitDetailContentView`:

* Removed the inline `shortstat` text and its associated divider from the main content area.
* Added a new bottom inset with a dedicated section for `shortstat`, including a divider, spacing, and styling for better visibility and layout consistency.

### Changes to `DiffView`:

* Adjusted the padding on `DiffTabView` to apply only to the top, instead of both top and bottom, for a cleaner layout.