### PR TITLE
No changes in commit diff

### DIFF
--- a/GitClient/Views/Commit/CommitDiffView.swift
+++ b/GitClient/Views/Commit/CommitDiffView.swift
@@ -15,12 +15,22 @@ struct CommitDiffView: View {
     @State private var commitFirst = ""
     @State private var commitSecond = ""
     @State private var filesChanges: [ExpandableModel<FileDiff>] = []
+    @State private var filesChangesIsEmpty = false
     @State private var shortstat = ""
     @State private var error: Error?
     @FocusState private var isFocused: Bool
 
     var body: some View {
         ScrollView {
+            if filesChangesIsEmpty {
+                LazyVStack(alignment: .center) {
+                    Label("No Changes", systemImage: "plusminus")
+                        .foregroundStyle(.secondary)
+                        .padding()
+                        .padding()
+                        .padding(.vertical, 40)
+                }
+            }
             FileDiffsView(expandableFileDiffs: $filesChanges)
                 .padding(.horizontal)
         }
@@ -85,10 +95,13 @@ struct CommitDiffView: View {
                     GitDiff(directory: folder, noRenames: false, commitRange: commitRange)
                 )
                 filesChanges = try Diff(raw: raw).fileDiffs.map { .init(isExpanded: true, model: $0) }
+                filesChangesIsEmpty = filesChanges.isEmpty
                 shortstat = try await Process.output(
                     GitDiff(directory: folder, noRenames: false, shortstat: true, commitRange: commitRange)
                 ).trimmingCharacters(in: .whitespacesAndNewlines)
-
+                if shortstat.isEmpty {
+                    shortstat = "No Changes"
+                }
             } catch {
                 self.error = error
             }

--- a/GitClient/Views/Commit/CommitDiffView.swift
+++ b/GitClient/Views/Commit/CommitDiffView.swift
@@ -82,11 +82,11 @@ struct CommitDiffView: View {
         Task {
             do {
                 let raw = try await Process.output(
-                    GitDiff(directory: folder, noRenames: false, cached: cached, commitRange: commitRange)
+                    GitDiff(directory: folder, noRenames: false, commitRange: commitRange)
                 )
                 filesChanges = try Diff(raw: raw).fileDiffs.map { .init(isExpanded: true, model: $0) }
                 shortstat = try await Process.output(
-                    GitDiff(directory: folder, noRenames: false, shortstat: true, cached: cached, commitRange: commitRange)
+                    GitDiff(directory: folder, noRenames: false, shortstat: true, commitRange: commitRange)
                 ).trimmingCharacters(in: .whitespacesAndNewlines)
 
             } catch {

--- a/GitClient/Views/Commit/CommitDiffView.swift
+++ b/GitClient/Views/Commit/CommitDiffView.swift
@@ -67,17 +67,17 @@ struct CommitDiffView: View {
             }
             .onChange(of: commitFirst + commitSecond, initial: true) { _, _ in
                 if commitFirst == Log.notCommitted.id {
-                    updateDiff(commitRange: commitSecond)
+                    updateDiff(cached: true, commitRange: commitSecond)
                 } else if commitSecond == Log.notCommitted.id {
-                    updateDiff(commitRange: commitFirst)
+                    updateDiff(cached: true, commitRange: commitFirst)
                 } else {
-                    updateDiff(commitRange: commitFirst + ".." + commitSecond)
+                    updateDiff(cached: false, commitRange: commitFirst + ".." + commitSecond)
                 }
             }
             .errorSheet($error)
     }
 
-    private func updateDiff(commitRange: String) {
+    private func updateDiff(cached: Bool, commitRange: String) {
         guard let folder else { return }
         Task {
             do {

--- a/GitClient/Views/Commit/CommitDiffView.swift
+++ b/GitClient/Views/Commit/CommitDiffView.swift
@@ -67,17 +67,17 @@ struct CommitDiffView: View {
             }
             .onChange(of: commitFirst + commitSecond, initial: true) { _, _ in
                 if commitFirst == Log.notCommitted.id {
-                    updateDiff(cached: true, commitRange: commitSecond)
+                    updateDiff(commitRange: commitSecond)
                 } else if commitSecond == Log.notCommitted.id {
-                    updateDiff(cached: true, commitRange: commitFirst)
+                    updateDiff(commitRange: commitFirst)
                 } else {
-                    updateDiff(cached: false, commitRange: commitFirst + ".." + commitSecond)
+                    updateDiff(commitRange: commitFirst + ".." + commitSecond)
                 }
             }
             .errorSheet($error)
     }
 
-    private func updateDiff(cached: Bool, commitRange: String) {
+    private func updateDiff(commitRange: String) {
         guard let folder else { return }
         Task {
             do {

--- a/GitClient/Views/Commit/CommitDiffView.swift
+++ b/GitClient/Views/Commit/CommitDiffView.swift
@@ -77,17 +77,17 @@ struct CommitDiffView: View {
             }
             .onChange(of: commitFirst + commitSecond, initial: true) { _, _ in
                 if commitFirst == Log.notCommitted.id {
-                    updateDiff(cached: true, commitRange: commitSecond)
+                    updateDiff(commitRange: commitSecond)
                 } else if commitSecond == Log.notCommitted.id {
-                    updateDiff(cached: true, commitRange: commitFirst)
+                    updateDiff(commitRange: commitFirst)
                 } else {
-                    updateDiff(cached: false, commitRange: commitFirst + ".." + commitSecond)
+                    updateDiff(commitRange: commitFirst + ".." + commitSecond)
                 }
             }
             .errorSheet($error)
     }
 
-    private func updateDiff(cached: Bool, commitRange: String) {
+    private func updateDiff(commitRange: String) {
         guard let folder else { return }
         Task {
             do {


### PR DESCRIPTION

<img width="1117" alt="Screenshot 2025-05-25 at 13 01 51" src="https://github.com/user-attachments/assets/46472c36-7e18-433c-876c-8ee3f872ce65" />

This pull request makes improvements to the `CommitDiffView` in `GitClient/Views/Commit/CommitDiffView.swift` to enhance user experience and simplify the code by removing unnecessary parameters. The key changes include adding a "No Changes" message when there are no file differences and refactoring the `updateDiff` method to remove the `cached` parameter.

### User Experience Improvements:
* Added a new state variable `filesChangesIsEmpty` to track whether there are any file changes. If no changes are detected, a "No Changes" message with a `Label` is displayed in the `ScrollView`. (`[GitClient/Views/Commit/CommitDiffView.swiftR18-R33](diffhunk://#diff-51f1ff4df91dce0f310e65c2690f4fe206a33ba9f281a6d38eca08caface7cd4R18-R33)`)
* Updated the `shortstat` string to display "No Changes" when it is empty, providing clearer feedback to the user. (`[GitClient/Views/Commit/CommitDiffView.swiftL70-R104](diffhunk://#diff-51f1ff4df91dce0f310e65c2690f4fe206a33ba9f281a6d38eca08caface7cd4L70-R104)`)

### Code Simplifications:
* Removed the `cached` parameter from the `updateDiff` method and its associated calls, simplifying the method signature and logic. (`[GitClient/Views/Commit/CommitDiffView.swiftL70-R104](diffhunk://#diff-51f1ff4df91dce0f310e65c2690f4fe206a33ba9f281a6d38eca08caface7cd4L70-R104)`)