### PR TITLE
Update folder handling in commit views to avoid force unwraps

### DIFF
--- a/GitClient/Views/ContentView.swift
+++ b/GitClient/Views/ContentView.swift
@@ -88,11 +88,11 @@ struct ContentView: View {
         } detail: {
             if let selectionLog, let subSelectionLogID {
                 CommitDiffView(selectionLogID: selectionLog.id, subSelectionLogID: subSelectionLogID)
-            } else {
+            } else if let selectionFolder {
                 switch selectionLog {
                 case .notCommitted:
                     CommitCreateView(
-                        folder: selectionFolder!,
+                        folder: selectionFolder,
                         isRefresh: $folderIsRefresh,
                         onCommit: {
                             self.selectionLog = nil
@@ -104,7 +104,7 @@ struct ContentView: View {
                         }
                     )
                 case .committed(let commit):
-                    CommitDetailStackView(commit: commit, folder: selectionFolder!)
+                    CommitDetailStackView(commit: commit, folder: selectionFolder)
                 case nil:
                     Text("No Selection")
                         .foregroundColor(.secondary)

--- a/GitClient/Views/Folder/CommitGraphView.swift
+++ b/GitClient/Views/Folder/CommitGraphView.swift
@@ -169,7 +169,7 @@ struct CommitGraphContentView: View {
 
                 // ノードを描く
                 ForEach(commits) { commit in
-                    if let point = position(of: commit) {
+                    if let point = position(of: commit), let folder {
                         GraphNode(
                             logID: commit.id,
                             selectionLogID: $selectionLogID,
@@ -177,7 +177,7 @@ struct CommitGraphContentView: View {
                         )
                             .position(point)
                             .commitContextMenu(
-                                folder: folder!,
+                                folder: folder,
                                 commit: commit.commit,
                                 logStore: logStore,
                                 isRefresh: $isRefresh,
@@ -195,7 +195,7 @@ struct CommitGraphContentView: View {
                             .offset(.init(width: textWidth / 2 + 14, height: 0))
                             .position(point)
                             .commitContextMenu(
-                                folder: folder!,
+                                folder: folder,
                                 commit: commit.commit,
                                 logStore: logStore,
                                 isRefresh: $isRefresh,

--- a/GitClient/Views/Folder/CommitLogView.swift
+++ b/GitClient/Views/Folder/CommitLogView.swift
@@ -79,15 +79,17 @@ struct CommitLogView: View {
                 Text("Uncommitted Changes")
                     .foregroundStyle(Color.secondary)
             case .committed(let commit):
-                CommitRowView(commit: commit)
-                    .commitContextMenu(
-                        folder: folder!,
-                        commit: commit,
-                        logStore: logStore,
-                        isRefresh: $isRefresh,
-                        showing: $showing,
-                        bindingError: $error
-                    )
+                if let folder {
+                    CommitRowView(commit: commit)
+                        .commitContextMenu(
+                            folder: folder,
+                            commit: commit,
+                            logStore: logStore,
+                            isRefresh: $isRefresh,
+                            showing: $showing,
+                            bindingError: $error
+                        )
+                }
             }
         }
     }


### PR DESCRIPTION
- Updated `ContentView` to use optional binding for `selectionFolder` instead of force unwrapping.
- Modified `CommitGraphContentView` to ensure `folder` is safely unwrapped before usage.
- Adjusted `CommitLogView` to implement optional binding when accessing `folder` to prevent runtime crashes.

