### PR TITLE
Update loading state

### DIFF
--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -432,11 +432,12 @@ struct FolderView: View {
             Task {
                 do {
                     try await GitFetchExecutor.shared.execute(GitPull(directory: folder.url, refspec: branch!.name))
+                    isLoading = false
                     await refreshModels()
                 } catch {
+                    isLoading = false
                     self.error = error
                 }
-                isLoading = false
             }
         } label: {
             Image(systemName: "arrow.down")
@@ -457,11 +458,12 @@ struct FolderView: View {
             Task {
                 do {
                     try await Process.output(GitPush(directory: folder.url))
+                    isLoading = false
                     await updateModels()
                 } catch {
+                    isLoading = false
                     self.error = error
                 }
-                isLoading = false
             }
         } label: {
             Image(systemName: "arrow.up")

--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -432,6 +432,7 @@ struct FolderView: View {
             Task {
                 do {
                     try await GitFetchExecutor.shared.execute(GitPull(directory: folder.url, refspec: branch!.name))
+                    syncState.shouldPull = false
                     isLoading = false
                     await refreshModels()
                 } catch {
@@ -458,6 +459,7 @@ struct FolderView: View {
             Task {
                 do {
                     try await Process.output(GitPush(directory: folder.url))
+                    syncState.shouldPush = false
                     isLoading = false
                     await updateModels()
                 } catch {


### PR DESCRIPTION
This pull request refines the `FolderView` in `GitClient/Views/Folder/FolderView.swift` by improving state management during Git operations. The changes ensure that `isLoading` is consistently updated and introduce new flags in `syncState` to track pull and push operations.

Enhancements to state management during Git operations:

* Updated the `GitPull` operation to set `syncState.shouldPull` to `false` and ensure `isLoading` is updated correctly after the operation completes or fails.
* Updated the `GitPush` operation to set `syncState.shouldPush` to `false` and ensure `isLoading` is updated correctly after the operation completes or fails.