### PR TITLE
Multiple author

### DIFF
--- a/GitClient/Models/Commands/GitLog.swift
+++ b/GitClient/Models/Commands/GitLog.swift
@@ -53,9 +53,7 @@ struct GitLog: Git {
             args.append("-G")
             args.append(g)
         }
-        if !author.isEmpty {
-            args.append("--author=\(author)")
-        }
+        args = args + authors.map { "--author=\($0)" }
         if !paths.isEmpty {
             args.append("--")
             args = args + paths
@@ -72,7 +70,7 @@ struct GitLog: Git {
     var grepAllMatch = false
     var s = ""
     var g = ""
-    var author = ""
+    var authors:[String] = []
     var paths: [String] = []
 
     func parse(for stdOut: String) throws -> [Commit] {

--- a/GitClient/Models/Observables/LogStore.swift
+++ b/GitClient/Models/Observables/LogStore.swift
@@ -31,8 +31,8 @@ import Observation
     private var g: String {
         searchTokens.filter { $0.kind == .g }.map { $0.text }.first ?? ""
     }
-    private var author: String {
-        searchTokens.filter { $0.kind == .author }.map { $0.text }.first ?? ""
+    private var authors: [String] {
+        searchTokens.filter { $0.kind == .author }.map { $0.text }
     }
     private var searchTokenRevisionRange: String {
         searchTokens.filter { $0.kind == .revisionRange }.map { $0.text }.first ?? ""
@@ -60,7 +60,7 @@ import Observation
             grepAllMatch: grepAllMatch,
             s: s,
             g: g,
-            author: author,
+            authors: authors,
             paths: paths
         )
     }

--- a/GitClient/Models/SearchTokensHandler.swift
+++ b/GitClient/Models/SearchTokensHandler.swift
@@ -54,15 +54,6 @@ struct SearchTokensHandler {
                         return true
                     }
                 }
-            case .author:
-                return newTokens.filter { token in
-                    switch token.kind {
-                    case .author:
-                        return token == newToken
-                    default:
-                        return true
-                    }
-                }
             case .revisionRange:
                 return newTokens.filter { token in
                     switch token.kind {
@@ -72,7 +63,7 @@ struct SearchTokensHandler {
                         return true
                     }
                 }
-            case .path:
+            case .author, .path:
                 return newTokens
             }
         } else {

--- a/GitClient/Models/SearchTokensHandler.swift
+++ b/GitClient/Models/SearchTokensHandler.swift
@@ -18,7 +18,7 @@ struct SearchTokensHandler {
         return Array(history.prefix(10))
     }
 
-    static func handle(oldTokens: [SearchToken], newTokens: [SearchToken]) -> [SearchToken] {
+    static func normalize(oldTokens: [SearchToken], newTokens: [SearchToken]) -> [SearchToken] {
         if let newToken = newToken(old: oldTokens, new: newTokens) {
             switch newToken.kind {
             case .grep, .grepAllMatch:

--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -147,7 +147,7 @@ struct FolderView: View {
             await refreshModels()
         }
         .onChange(of: searchTokens, { oldValue, newValue in
-            searchTokens = SearchTokensHandler.handle(oldTokens: oldValue, newTokens: newValue)
+            searchTokens = SearchTokensHandler.normalize(oldTokens: oldValue, newTokens: newValue)
             logStore.searchTokens = searchTokens
             searchTask?.cancel()
             searchTask = Task {

--- a/GitClientTests/SearchTokensHandlerTests.swift
+++ b/GitClientTests/SearchTokensHandlerTests.swift
@@ -97,13 +97,13 @@ struct SearchTokensHandlerTests {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .author, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .author, text: "a"), .init(kind: .author, text: "b")]
         let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
-        #expect(handledTokens == [.init(kind: .grep, text: "c"), .init(kind: .author, text: "b")] )
+        #expect(handledTokens == [.init(kind: .grep, text: "c"), .init(kind: .author, text: "a"), .init(kind: .author, text: "b")] )
     }
 
     @Test func handleAuhorInEdit() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .author, text: "a"), .init(kind: .grep, text: "c")]
         let newTokens: [SearchToken] = [.init(kind: .author, text: "a"), .init(kind: .author, text: "c")]
         let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
-        #expect(handledTokens == [.init(kind: .author, text: "c")] )
+        #expect(handledTokens == [.init(kind: .author, text: "a"), .init(kind: .author, text: "c")] )
     }
 }

--- a/GitClientTests/SearchTokensHandlerTests.swift
+++ b/GitClientTests/SearchTokensHandlerTests.swift
@@ -12,7 +12,7 @@ struct SearchTokensHandlerTests {
     @Test func handleGrep() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grepAllMatch, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grepAllMatch, text: "a"), .init(kind: .grep, text: "b")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens.first!.kind == .grep )
         #expect(handledTokens.last!.kind == .grep )
     }
@@ -20,7 +20,7 @@ struct SearchTokensHandlerTests {
     @Test func handleGrepInEdit() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grepAllMatch, text: "a"), .init(kind: .grepAllMatch, text: "b")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "a"), .init(kind: .grepAllMatch, text: "b")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens.first!.kind == .grep )
         #expect(handledTokens.last!.kind == .grep )
     }
@@ -28,7 +28,7 @@ struct SearchTokensHandlerTests {
     @Test func handleGrepAllMath() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "a"), .init(kind: .grepAllMatch, text: "b")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens.first!.kind == .grepAllMatch )
         #expect(handledTokens.last!.kind == .grepAllMatch )
     }
@@ -36,7 +36,7 @@ struct SearchTokensHandlerTests {
     @Test func handleGrepAllMathInEdit() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "a"), .init(kind: .grep, text: "b")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "a"), .init(kind: .grepAllMatch, text: "b")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens.first!.kind == .grepAllMatch )
         #expect(handledTokens.last!.kind == .grepAllMatch )
     }
@@ -44,7 +44,7 @@ struct SearchTokensHandlerTests {
     @Test func handleS() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .g, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .g, text: "a"), .init(kind: .s, text: "b"),]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens.last!.kind == .s )
         #expect(handledTokens.count == 2 )
     }
@@ -52,7 +52,7 @@ struct SearchTokensHandlerTests {
     @Test func handleS2() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .s, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .s, text: "a"), .init(kind: .s, text: "b"),]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens == [.init(kind: .grep, text: "c"), .init(kind: .s, text: "b"),] )
 
     }
@@ -60,14 +60,14 @@ struct SearchTokensHandlerTests {
     @Test func handleSInEdit() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .g, text: "a"), .init(kind: .grep, text: "c")]
         let newTokens: [SearchToken] = [.init(kind: .s, text: "a"), .init(kind: .grep, text: "c")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens == newTokens )
     }
 
     @Test func handleG() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .s, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .s, text: "a"), .init(kind: .g, text: "b")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens.last!.kind == .g )
         #expect(handledTokens.count == 2 )
     }
@@ -75,35 +75,35 @@ struct SearchTokensHandlerTests {
     @Test func handleG2() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .g, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .g, text: "a"), .init(kind: .g, text: "b")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens == [.init(kind: .grep, text: "c"), .init(kind: .g, text: "b")])
     }
 
     @Test func handleGInEdit() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .s, text: "a"), .init(kind: .grep, text: "c")]
         let newTokens: [SearchToken] = [.init(kind: .g, text: "a"), .init(kind: .grep, text: "c")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens == newTokens )
     }
 
     @Test func handleAuthor() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .s, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .s, text: "a"), .init(kind: .author, text: "a")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens == [.init(kind: .grep, text: "c"), .init(kind: .s, text: "a"), .init(kind: .author, text: "a")] )
     }
 
     @Test func handleAuthor2() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .author, text: "a")]
         let newTokens: [SearchToken] = [.init(kind: .grep, text: "c"), .init(kind: .author, text: "a"), .init(kind: .author, text: "b")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens == [.init(kind: .grep, text: "c"), .init(kind: .author, text: "b")] )
     }
 
     @Test func handleAuhorInEdit() async throws {
         let oldTokens: [SearchToken] = [.init(kind: .author, text: "a"), .init(kind: .grep, text: "c")]
         let newTokens: [SearchToken] = [.init(kind: .author, text: "a"), .init(kind: .author, text: "c")]
-        let handledTokens = SearchTokensHandler.handle(oldTokens: oldTokens, newTokens: newTokens)
+        let handledTokens = SearchTokensHandler.normalize(oldTokens: oldTokens, newTokens: newTokens)
         #expect(handledTokens == [.init(kind: .author, text: "c")] )
     }
 }


### PR DESCRIPTION
https://git-scm.com/docs/git-log#Documentation/git-log.txt---authorltpatterngt

> --author=<pattern>
> --committer=<pattern>
> Limit the commits output to ones with author/committer header lines that match the specified pattern (regular expression). With more than one --author=<pattern>, commits whose author matches any of the given patterns are chosen (similarly for multiple --committer=<pattern>).
> 

===========

This pull request introduces changes to support multiple authors in search filters, refactors the `SearchTokensHandler` for improved clarity, and updates related tests. The most significant changes include replacing single-author handling with multi-author support, renaming the `handle` method to `normalize` for better semantic alignment, and modifying tests to reflect these updates.

### Support for multiple authors:
* Updated `GitLog.swift` to replace single-author handling (`author`) with multi-author support (`authors`) and adjusted the logic for constructing Git command arguments. [[1]](diffhunk://#diff-37eff570e1f5e2291c5bd8370430f624c8ea799690b6965d120eb76bc4253fccL56-R56) [[2]](diffhunk://#diff-37eff570e1f5e2291c5bd8370430f624c8ea799690b6965d120eb76bc4253fccL75-R73)
* Updated `LogStore.swift` to support multiple authors in search tokens by changing `author` to `authors`. [[1]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522L34-R35) [[2]](diffhunk://#diff-83d76bf6bb027587384a3aaad45adfe25c0b97840e863834478b4f9c90442522L63-R63)

### Refactoring for clarity:
* Renamed `handle` method in `SearchTokensHandler.swift` to `normalize` for improved semantic clarity.
* Consolidated logic for handling `author` tokens in `SearchTokensHandler.swift` by removing redundant filtering and aligning behavior with other token types. [[1]](diffhunk://#diff-f7bec91803b611b449f7c79471b9dadde937cf2beebc3b84d5f8b9988c1dd4abL57-L65) [[2]](diffhunk://#diff-f7bec91803b611b449f7c79471b9dadde937cf2beebc3b84d5f8b9988c1dd4abL75-R66)

### Test updates:
* Updated all test cases in `SearchTokensHandlerTests.swift` to use the renamed `normalize` method and to reflect the changes in token handling logic.

### UI integration:
* Modified `FolderView.swift` to use the updated `normalize` method for handling search tokens, ensuring compatibility with the refactored logic.