### PR TITLE
Fix the error sheet display looped 

### DIFF
--- a/GitClient/Views/Folder/FolderView.swift
+++ b/GitClient/Views/Folder/FolderView.swift
@@ -6,6 +6,8 @@
 //
 
 import SwiftUI
+import Foundation
+import AppKit
 
 struct FolderView: View {
     @Environment(\.appearsActive) private var appearsActive
@@ -233,11 +235,9 @@ struct FolderView: View {
                 }
             }
         }
-        .onChange(of: appearsActive) { _, new in
-            if new {
-                Task {
-                    await updateModels()
-                }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.willBecomeActiveNotification)) { _ in
+            Task {
+                await updateModels()
             }
         }
     }


### PR DESCRIPTION
<img width="1117" alt="Screenshot 2025-06-05 at 19 35 23" src="https://github.com/user-attachments/assets/e71546df-326d-4688-8226-605e578d7628" />

Fixed an issue where the sheet display looped when an error occurred in refreshModels() on macOS 15. ( Occurs when there is no .git in the selected folder, etc.)

In macOS 15, it began to occur because appearanceActive has changed even when the sheet is displayed/hiden.
