### PR TITLE
Add .buttonStyle(.borderedProminent)

### DIFF
--- a/GitClient/Views/Commit/CommitCreateView.swift
+++ b/GitClient/Views/Commit/CommitCreateView.swift
@@ -268,6 +268,7 @@ struct CommitCreateView: View {
                             }
                         }
                     }
+                    .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.init(.return))
                     .disabled(cachedDiffRaw.isEmpty || commitMessage.isEmpty)
                     Toggle("Amend", isOn: $isAmend)

--- a/GitClient/Views/Commit/CommitMessageSnippetView.swift
+++ b/GitClient/Views/Commit/CommitMessageSnippetView.swift
@@ -76,6 +76,7 @@ struct CommitMessageSnippetView: View {
                         self.error = error
                     }
                 }
+                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.init(.return))
                 .disabled(editCommitMessageSnippet.isEmpty)
                 .padding()

--- a/GitClient/Views/Folder/Sheets/AmendCommitSheet.swift
+++ b/GitClient/Views/Folder/Sheets/AmendCommitSheet.swift
@@ -44,6 +44,7 @@ struct AmendCommitSheet: View {
                         }
                     }
                     .disabled(message.isEmpty)
+                    .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.init(.return))
                 }
                 .padding(.top)

--- a/GitClient/Views/Folder/Sheets/CreateNewBranchSheet.swift
+++ b/GitClient/Views/Folder/Sheets/CreateNewBranchSheet.swift
@@ -50,6 +50,7 @@ struct CreateNewBranchSheet: View {
                             }
                         }
                     }
+                    .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.init(.return))
                     .disabled(newBranchName.isEmpty)
                 }

--- a/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
+++ b/GitClient/Views/Folder/Sheets/CreateNewTagSheet.swift
@@ -85,6 +85,7 @@ struct CreateNewTagSheet: View {
                                 }
                             }
                         }
+                        .buttonStyle(.borderedProminent)
                         .keyboardShortcut(.init(.return))
                         .disabled(newTagname.isEmpty)
                     }

--- a/GitClient/Views/Folder/Sheets/RenameBranchSheet.swift
+++ b/GitClient/Views/Folder/Sheets/RenameBranchSheet.swift
@@ -49,6 +49,7 @@ struct RenameBranchSheet: View {
                             }
                         }
                     }
+                    .buttonStyle(.borderedProminent)
                     .keyboardShortcut(.init(.return))
                     .disabled(newBranchName.isEmpty)
                 }

--- a/GitClient/Views/StashChanged/StashChangedContentView.swift
+++ b/GitClient/Views/StashChanged/StashChangedContentView.swift
@@ -74,6 +74,7 @@ struct StashChangedContentView: View {
                                 }
                             }
                         }
+                        .buttonStyle(.borderedProminent)
                         .keyboardShortcut(.init(.return))
                         .disabled(selectionStashID == nil)
                     }


### PR DESCRIPTION
The keyboard shortcut (.init(.return)) button used to be blue, but it remains unchanged in Xcode 26. Therefore, I need to make a change.