### PR TITLE
Update commit hash display

### DIFF
--- a/GitClient/Views/Commit/CommitDetailHeaderView.swift
+++ b/GitClient/Views/Commit/CommitDetailHeaderView.swift
@@ -16,7 +16,7 @@ struct CommitDetailHeaderView: View {
             HStack {
                 Text(commit.hash.prefix(5))
                     .textSelection(.disabled)
-                    .help(commit.hash)
+                    .help("Commit Hash: " + commit.hash)
                     .contextMenu {
                         Button("Copy " + commit.hash) {
                             let pasteboard = NSPasteboard.general
@@ -24,7 +24,7 @@ struct CommitDetailHeaderView: View {
                             pasteboard.setString(commit.hash, forType: .string)
                         }
                     }
-                Image(systemName: "arrow.left")
+                Image(systemName: "arrow.right")
                 HStack(spacing: 0) {
                     ForEach(commit.parentHashes, id: \.self) { hash in
                         if hash == commit.parentHashes.first {


### PR DESCRIPTION
I changed the direction of the arrow to be the same as the following figure
https://git-scm.com/book/en/v2/Git-Branching-Rebasing
> <img width="712" height="611" alt="スクリーンショット 2025-10-04 9 47 46" src="https://github.com/user-attachments/assets/7906f012-650c-4ea5-af60-d193845a3525" />
