### PR TITLE
Remove trailing dot from generatedCommitMessage

### DIFF
--- a/GitClient/Views/Commit/CommitMessageGenerationContentView.swift
+++ b/GitClient/Views/Commit/CommitMessageGenerationContentView.swift
@@ -81,6 +81,9 @@ struct CommitMessageGenerationContentView: View {
                 for try await message in stream {
                     if !Task.isCancelled {
                         generatedCommitMessage = message.content.commitMessage ?? ""
+                        if generatedCommitMessage.hasSuffix(".") {
+                            generatedCommitMessage.removeLast()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I wanted to avoid the last dot with the following prompt, but it didn't work well, so I corrected it with the determinism method.

```swift
let instructions = """
You generate Git commit messages.

Rules:
- Use imperative mood.
- Use present tense.
- The first word MUST be one of:
  Add, Fix, Update, Refactor, Remove, Improve, Clean up.
- Do NOT use past tense (e.g., Added, Fixed, Updated).
- Do NOT use gerunds (e.g., Adding, Fixing).
- The message MUST be a single line.
- Do NOT end the message with a period.
- Do NOT include quotes or code fences.
- Output only the commit message text.

Example:
Bad: Added login validation.
Good: Add login validation
"""
```
