### PR TITLE
Update the commit date frequently

### DIFF
--- a/GitClient/Models/Commit.swift
+++ b/GitClient/Models/Commit.swift
@@ -27,15 +27,10 @@ struct Commit: Hashable, Identifiable {
         return DateFormatter.localizedString(from: date, dateStyle: .short, timeStyle: .short)
     }
     var authorDateRelative: String {
-        authorDateRelative(relativeTo: .now)
-    }
-    func authorDateRelative(relativeTo now: Date) -> String {
         guard let date = try? Date(authorDate, strategy: .iso8601) else {
             return ""
         }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.dateTimeStyle = .named
-        return formatter.localizedString(for: date, relativeTo: now)
+        return date.formatted(.relative(presentation: .named))
     }
     var title: String
     var body: String

--- a/GitClient/Models/Commit.swift
+++ b/GitClient/Models/Commit.swift
@@ -15,24 +15,27 @@ struct Commit: Hashable, Identifiable {
     var authorEmail: String
     var authorDate: String
     var authorDateDisplay: String {
-        guard let date = ISO8601DateFormatter().date(from: authorDate) else {
+        guard let date = try? Date(authorDate, strategy: .iso8601) else {
             return ""
         }
         return DateFormatter.localizedString(from: date, dateStyle: .long, timeStyle: .long)
     }
     var authorDateDisplayShort: String {
-        guard let date = ISO8601DateFormatter().date(from: authorDate) else {
+        guard let date = try? Date(authorDate, strategy: .iso8601) else {
             return ""
         }
         return DateFormatter.localizedString(from: date, dateStyle: .short, timeStyle: .short)
     }
     var authorDateRelative: String {
-        guard let date = ISO8601DateFormatter().date(from: authorDate) else {
+        authorDateRelative(relativeTo: .now)
+    }
+    func authorDateRelative(relativeTo now: Date) -> String {
+        guard let date = try? Date(authorDate, strategy: .iso8601) else {
             return ""
         }
         let formatter = RelativeDateTimeFormatter()
         formatter.dateTimeStyle = .named
-        return formatter.localizedString(for: date, relativeTo: Date())
+        return formatter.localizedString(for: date, relativeTo: now)
     }
     var title: String
     var body: String

--- a/GitClient/Views/Commit/CommitCreateView.swift
+++ b/GitClient/Views/Commit/CommitCreateView.swift
@@ -78,6 +78,9 @@ struct CommitCreateView: View {
             }
 
             if diff != nil {
+                Divider()
+                    .padding()
+
                 UnstagedView(
                     fileDiffs: $expandableFileDiffs,
                     status: notStagedHeaderCaption,

--- a/GitClient/Views/Folder/CommitRowView.swift
+++ b/GitClient/Views/Folder/CommitRowView.swift
@@ -21,6 +21,7 @@ struct CommitRowView: View {
                         .font(.caption)
                 }
             }
+            //
             HStack {
                 Icon(size: .small, authorEmail: commit.authorEmail, authorInitial: String(commit.author.initial.prefix(1)))
                 Text(commit.author)

--- a/GitClient/Views/Folder/CommitRowView.swift
+++ b/GitClient/Views/Folder/CommitRowView.swift
@@ -21,7 +21,6 @@ struct CommitRowView: View {
                         .font(.caption)
                 }
             }
-            //
             HStack {
                 Icon(size: .small, authorEmail: commit.authorEmail, authorInitial: String(commit.author.initial.prefix(1)))
                 Text(commit.author)

--- a/GitClient/Views/Folder/CommitRowView.swift
+++ b/GitClient/Views/Folder/CommitRowView.swift
@@ -25,8 +25,8 @@ struct CommitRowView: View {
                 Icon(size: .small, authorEmail: commit.authorEmail, authorInitial: String(commit.author.initial.prefix(1)))
                 Text(commit.author)
                 Spacer()
-                TimelineView(.periodic(from: .now, by: 60)) { context in
-                    Text(commit.authorDateRelative(relativeTo: context.date))
+                TimelineView(.periodic(from: .now, by: 60)) { _ in
+                    Text(commit.authorDateRelative)
                 }
             }
             .lineLimit(1)

--- a/GitClient/Views/Folder/CommitRowView.swift
+++ b/GitClient/Views/Folder/CommitRowView.swift
@@ -11,7 +11,7 @@ struct CommitRowView: View {
     var commit: Commit
 
     var body: some View {
-        VStack (alignment: .leading) {
+        VStack(alignment: .leading) {
             HStack(alignment: .firstTextBaseline) {
                 Text(commit.title)
                 Spacer()
@@ -25,7 +25,9 @@ struct CommitRowView: View {
                 Icon(size: .small, authorEmail: commit.authorEmail, authorInitial: String(commit.author.initial.prefix(1)))
                 Text(commit.author)
                 Spacer()
-                Text(commit.authorDateRelative)
+                TimelineView(.periodic(from: .now, by: 60)) { context in
+                    Text(commit.authorDateRelative(relativeTo: context.date))
+                }
             }
             .lineLimit(1)
             .foregroundStyle(.tertiary)


### PR DESCRIPTION
Frequently update the date display of CommitRowView.
Consider using FormatStyle instead of ISO8601DateFormatter for better performance.
ref: https://developer.apple.com/documentation/foundation/iso8601dateformatter