### PR TITLE
Allow reordering folders

### DIFF
--- a/GitClient.xcodeproj/project.pbxproj
+++ b/GitClient.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		61EBD7CF28E922510009ED92 /* GitBranch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EBD7CE28E922510009ED92 /* GitBranch.swift */; };
 		61EBD7D128E940C30009ED92 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EBD7D028E940C30009ED92 /* Branch.swift */; };
 		61EBD7D328E966190009ED92 /* GitSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EBD7D228E966190009ED92 /* GitSwitch.swift */; };
+		61F01DE22E5F00000867A9F7 /* FolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F01DE12E5F00000867A9F6 /* FolderTests.swift */; };
 		61F5B7AF2CBBB066005C736E /* MergeCommitContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F5B7AE2CBBB066005C736E /* MergeCommitContentView.swift */; };
 		61FAF4942C6835EC000B7ACB /* CommitMessageSnippetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FAF4932C6835EC000B7ACB /* CommitMessageSnippetView.swift */; };
 		61FAF4962C684569000B7ACB /* Notification+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FAF4952C684569000B7ACB /* Notification+.swift */; };
@@ -304,6 +305,7 @@
 		61EBD7CE28E922510009ED92 /* GitBranch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranch.swift; sourceTree = "<group>"; };
 		61EBD7D028E940C30009ED92 /* Branch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Branch.swift; sourceTree = "<group>"; };
 		61EBD7D228E966190009ED92 /* GitSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitSwitch.swift; sourceTree = "<group>"; };
+		61F01DE12E5F00000867A9F6 /* FolderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderTests.swift; sourceTree = "<group>"; };
 		61F5B7AE2CBBB066005C736E /* MergeCommitContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeCommitContentView.swift; sourceTree = "<group>"; };
 		61FAF4932C6835EC000B7ACB /* CommitMessageSnippetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageSnippetView.swift; sourceTree = "<group>"; };
 		61FAF4952C684569000B7ACB /* Notification+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+.swift"; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				61347EFF28D5D16D00625FC4 /* DiffTests.swift */,
 				619759552C8C9A9300E9CA4F /* GitDiffNumStatTests.swift */,
 				61B5BBB62C9B97310087A9F6 /* BranchTests.swift */,
+				61F01DE12E5F00000867A9F6 /* FolderTests.swift */,
 				61D34C8C2CAC394A0032A22A /* GitLogTests.swift */,
 				61094D522DFA4E7C00D7B8AA /* GitRevParseTests.swift */,
 				614DE8152DA0C2E700FC582E /* GitShowShortstatTests.swift */,
@@ -876,6 +879,7 @@
 				6131AC872DF268BF00DFBCB5 /* GitStatusTests.swift in Sources */,
 				61094D532DFA4E7C00D7B8AA /* GitRevParseTests.swift in Sources */,
 				61B5BBB72C9B97310087A9F6 /* BranchTests.swift in Sources */,
+				61F01DE22E5F00000867A9F7 /* FolderTests.swift in Sources */,
 				61CAEDEC2DCEE266009AADD9 /* ExpandableModelTests.swift in Sources */,
 				619759562C8C9A9300E9CA4F /* GitDiffNumStatTests.swift in Sources */,
 				61D34C8D2CAC394A0032A22A /* GitLogTests.swift in Sources */,

--- a/GitClient/Views/ContentView.swift
+++ b/GitClient/Views/ContentView.swift
@@ -47,20 +47,29 @@ struct ContentView: View {
                     .foregroundStyle(.secondary)
                     .padding()
                 } else {
-                    List(decodedFolders, id: \.url, selection: $selectionFolderURL) { folder in
-                        Label(folder.displayName, systemImage: "folder")
-                            .help(folder.url.path)
+                    List(selection: $selectionFolderURL) {
+                        ForEach(decodedFolders, id: \.url) { folder in
+                            HStack {
+                                Label(folder.displayName, systemImage: "folder")
+                                    .help(folder.url.path)
+                                Spacer()
+                                Image(systemName: "line.3.horizontal")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .tag(folder.url)
                             .contextMenu {
                                 Button("Delete") {
                                     var folders = decodedFolders
                                     folders.removeAll { $0 == folder }
-                                    do {
-                                        try self.folders = JSONEncoder().encode(folders)
-                                    } catch {
-                                        self.error = error
-                                    }
+                                    persistFolders(folders)
                                 }
                             }
+                        }
+                        .onMove(perform: { source, destination in
+                            var folders = decodedFolders
+                            folders.move(fromOffsets: source, toOffset: destination)
+                            persistFolders(folders)
+                        })
                     }
                 }
             }
@@ -79,11 +88,7 @@ struct ContentView: View {
                                         var folders = decodedFolders
                                         folders.removeAll { $0 == chooseFolder }
                                         folders.insert(chooseFolder, at: 0)
-                                        do {
-                                            try self.folders = JSONEncoder().encode(folders)
-                                        } catch {
-                                            self.error = error
-                                        }
+                                        persistFolders(folders)
                                     }
                                 }
                             }
@@ -146,6 +151,14 @@ struct ContentView: View {
         .errorSheet($error)
         .environment(\.folder, selectionFolderURL)
         .environment(\.systemLanguageModelAvailability, systemLanguageModelAvailability)
+    }
+
+    private func persistFolders(_ folders: [Folder]) {
+        do {
+            try self.folders = JSONEncoder().encode(folders)
+        } catch {
+            self.error = error
+        }
     }
 }
 

--- a/GitClientTests/FolderTests.swift
+++ b/GitClientTests/FolderTests.swift
@@ -1,0 +1,42 @@
+//
+//  FolderTests.swift
+//  GitClientTests
+//
+
+import Foundation
+import Testing
+@testable import Changes
+
+struct FolderTests {
+
+    @Test
+    func encodeDecodePreservesFolderOrder() throws {
+        let urls = [
+            URL(fileURLWithPath: "/projects/alpha"),
+            URL(fileURLWithPath: "/projects/beta"),
+            URL(fileURLWithPath: "/projects/gamma"),
+        ]
+        let folders = urls.map { Folder(url: $0) }
+
+        let data = try JSONEncoder().encode(folders)
+        let decoded = try JSONDecoder().decode([Folder].self, from: data)
+
+        #expect(decoded.map(\.url) == urls)
+    }
+
+    @Test
+    func moveThenEncodeDecodePreservesReorderedFolders() throws {
+        let urls = [
+            URL(fileURLWithPath: "/projects/alpha"),
+            URL(fileURLWithPath: "/projects/beta"),
+            URL(fileURLWithPath: "/projects/gamma"),
+        ]
+        var folders = urls.map { Folder(url: $0) }
+        folders.move(fromOffsets: IndexSet(integer: 2), toOffset: 0)
+
+        let data = try JSONEncoder().encode(folders)
+        let decoded = try JSONDecoder().decode([Folder].self, from: data)
+
+        #expect(decoded.map(\.url) == [urls[2], urls[0], urls[1]])
+    }
+}


### PR DESCRIPTION
The more repositories you add, the harder it is to scan and find each one in the list. This change allows manual ordering.

<img width="2692" height="1451" alt="Screenshot 2026-05-18 at 12 22 12 PM" src="https://github.com/user-attachments/assets/3c12e4c1-7da9-4681-b9fa-f1dd8db8607b" />

I considered alphabetical ordering, but I would not want to break existing workflows.