### PR TITLE
Fix commit diff scroll layout

### DIFF
--- a/GitClient/Views/Commit/CommitCreateView.swift
+++ b/GitClient/Views/Commit/CommitCreateView.swift
@@ -59,54 +59,56 @@ struct CommitCreateView: View {
     
     var body: some View {
         ScrollView {
-            if cachedDiff != nil {
-                StagedView(
-                    fileDiffs: $cachedExpandableFileDiffs,
-                    status: cachedDiffShortStat,
-                    onSelectFileDiff: { fileDiff in
-                        if let newDiff = self.cachedDiff?.updateFileDiffStage(fileDiff, stage: false) {
-                            restorePatch(newDiff)
-                        }
-                    },
-                    onSelectChunk: status?.unmergedFiles.isEmpty == false ? nil : { fileDiff, chunk in
-                        if let newDiff = self.cachedDiff?.updateChunkStage(chunk, in: fileDiff, stage: false) {
-                            restorePatch(newDiff)
-                        }
-                    }
-                )
-                .padding(.top)
-            }
-
-            if diff != nil {
-                Divider()
-                    .padding()
-
-                UnstagedView(
-                    fileDiffs: $expandableFileDiffs,
-                    status: notStagedHeaderCaption,
-                    untrackedFiles: status?.untrackedFiles ?? [],
-                    onSelectFileDiff: { fileDiff in
-                        if let newDiff = self.diff?.updateFileDiffStage(fileDiff, stage: true) {
-                            addPatch(newDiff)
-                        }
-                    },
-                    onSelectChunk: status?.unmergedFiles.isEmpty == false ? nil : { fileDiff, chunk in
-                        if let newDiff = self.diff?.updateChunkStage(chunk, in: fileDiff, stage: true) {
-                            addPatch(newDiff)
-                        }
-                    },
-                    onSelectUntrackedFile: { file in
-                        Task {
-                            do {
-                                try await Process.output(GitAddPathspec(directory: folder.url, pathspec: file))
-                                await updateChanges()
-                            } catch {
-                                self.error = error
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if cachedDiff != nil {
+                    StagedView(
+                        fileDiffs: $cachedExpandableFileDiffs,
+                        status: cachedDiffShortStat,
+                        onSelectFileDiff: { fileDiff in
+                            if let newDiff = self.cachedDiff?.updateFileDiffStage(fileDiff, stage: false) {
+                                restorePatch(newDiff)
+                            }
+                        },
+                        onSelectChunk: status?.unmergedFiles.isEmpty == false ? nil : { fileDiff, chunk in
+                            if let newDiff = self.cachedDiff?.updateChunkStage(chunk, in: fileDiff, stage: false) {
+                                restorePatch(newDiff)
                             }
                         }
-                    }
-                )
-                .padding(.bottom)
+                    )
+                    .padding(.top)
+                }
+
+                if diff != nil {
+                    Divider()
+                        .padding()
+
+                    UnstagedView(
+                        fileDiffs: $expandableFileDiffs,
+                        status: notStagedHeaderCaption,
+                        untrackedFiles: status?.untrackedFiles ?? [],
+                        onSelectFileDiff: { fileDiff in
+                            if let newDiff = self.diff?.updateFileDiffStage(fileDiff, stage: true) {
+                                addPatch(newDiff)
+                            }
+                        },
+                        onSelectChunk: status?.unmergedFiles.isEmpty == false ? nil : { fileDiff, chunk in
+                            if let newDiff = self.diff?.updateChunkStage(chunk, in: fileDiff, stage: true) {
+                                addPatch(newDiff)
+                            }
+                        },
+                        onSelectUntrackedFile: { file in
+                            Task {
+                                do {
+                                    try await Process.output(GitAddPathspec(directory: folder.url, pathspec: file))
+                                    await updateChanges()
+                                } catch {
+                                    self.error = error
+                                }
+                            }
+                        }
+                    )
+                    .padding(.bottom)
+                }
             }
 
             if let updateChangesError {

--- a/GitClient/Views/Commit/StageFileDiffView.swift
+++ b/GitClient/Views/Commit/StageFileDiffView.swift
@@ -19,10 +19,11 @@ struct StageFileDiffView: View {
 
     var body: some View {
         DisclosureGroup(isExpanded: $expandableFileDiff.isExpanded) {
-            LazyVStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 8) {
                 ForEach(fileDiff.chunks) { chunk in
                     HStack(spacing: 0) {
                         ChunkView(chunk: chunk, filePath: fileDiff.toFilePath)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                         Spacer(minLength: 0)
                         Button {
                             onSelectChunk?(fileDiff, chunk)
@@ -35,6 +36,7 @@ struct StageFileDiffView: View {
                         .padding(.vertical)
                         .disabled(onSelectChunk == nil)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
             .padding(.top, 8)

--- a/GitClient/Views/Commit/StageFileDiffsView.swift
+++ b/GitClient/Views/Commit/StageFileDiffsView.swift
@@ -1,12 +1,12 @@
 //
-//  StagedFileDiffsView.swift
+//  StageFileDiffsView.swift
 //  GitClient
 //
 //  Created by Makoto Aoyama on 2025/03/15.
 //
 import SwiftUI
 
-struct StagedFileDiffView: View {
+struct StageFileDiffsView: View {
     @Binding var expandableFileDiffs: [ExpandableModel<FileDiff>]
     var selectButtonImageSystemName: String
     var selectButtonHelp: String

--- a/GitClient/Views/Commit/StageFileDiffsView.swift
+++ b/GitClient/Views/Commit/StageFileDiffsView.swift
@@ -16,7 +16,7 @@ struct StagedFileDiffView: View {
     @Environment(\.collapseAllFiles) private var collapseAllFilesID: UUID?
 
     var body: some View {
-        LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+        VStack(alignment: .leading, spacing: 0) {
             ForEach($expandableFileDiffs, id: \.self) { $fileDiff in
                 StageFileDiffView(
                     expandableFileDiff: $fileDiff,
@@ -28,6 +28,7 @@ struct StagedFileDiffView: View {
             }
             .font(Font.system(.body, design: .monospaced))
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onChange(of: expandAllFilesID) { _, _ in
             expandableFileDiffs = expandableFileDiffs.map { ExpandableModel(isExpanded: true, model: $0.model)}
         }

--- a/GitClient/Views/Commit/StagedView.swift
+++ b/GitClient/Views/Commit/StagedView.swift
@@ -25,7 +25,7 @@ struct StagedView: View {
                         .padding(.trailing)
                 }
             } else {
-                StagedFileDiffView(
+                StageFileDiffsView(
                     expandableFileDiffs: $fileDiffs,
                     selectButtonImageSystemName: "minus.circle",
                     selectButtonHelp: "Unstage This Hunk",

--- a/GitClient/Views/Commit/UnstagedView.swift
+++ b/GitClient/Views/Commit/UnstagedView.swift
@@ -28,7 +28,7 @@ struct UnstagedView: View {
                         .padding(.trailing)
                 }
             }
-            StagedFileDiffView(
+            StageFileDiffsView(
                 expandableFileDiffs: $fileDiffs,
                 selectButtonImageSystemName: "plus.circle",
                 selectButtonHelp: "Stage This Hunk",


### PR DESCRIPTION
## Summary

Fixed an issue in the commit creation view where the diff area could turn blank or jump back while scrolling when staged and unstaged diffs were shown together.

## Changes

- Place staged and unstaged sections under a single top-level `LazyVStack` directly inside `CommitCreateView`'s `ScrollView`
- Change the internal staged/unstaged diff lists to use `VStack`
- Adjust chunk row width so diff content does not shrink after switching those lists to `VStack`
- Preserve the existing staged/unstaged layout and hunk-level stage/unstage actions

## Background

During investigation, the issue reproduced when large staged and unstaged diff lists were rendered as separate lazy lists inside the same `ScrollView`. That structure made the scroll layout/offset unstable while scrolling.

The issue did not reproduce when only staged or only unstaged changes were shown; it reproduced when both sections were visible together.

## Verification

- Confirmed the scroll jump/blank area no longer occurs with both staged and unstaged changes visible
- Confirmed the existing staged/unstaged UI and hunk actions are preserved
