### PR TITLE
Update CI Xcode to 26.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,7 +88,7 @@ jobs:
     - if: matrix.build-mode == 'manual'
       shell: bash
       run: |
-        sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+        sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
         xcodebuild -scheme GitClient CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination "platform=macOS" -disableAutomaticPackageResolution
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Select Xcode 26.6 in test, release, and CodeQL workflows

