### PR TITLE
Use macos-26 for CodeQL Swift analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-26') || 'ubuntu-latest' }}
     permissions:
       # required for all workflows
       security-events: write


### PR DESCRIPTION
## Summary
- Run the Swift CodeQL job on macos-26 so Xcode 26.6 is available
- Keep the actions analysis job on ubuntu-latest

## Why
The CodeQL workflow selected /Applications/Xcode_26.6.app, but the Swift job was still running on macos-latest. That runner image did not have the Xcode 26.6 app path, so xcode-select failed.
