### PR TITLE
Update buttons position in commit create view

### DIFF
--- a/GitClient/Views/Commit/CommitCreateView.swift
+++ b/GitClient/Views/Commit/CommitCreateView.swift
@@ -118,7 +118,8 @@ struct CommitCreateView: View {
                     .font(Font.system(.body, design: .monospaced))
             }
         }
-        .safeAreaBar(edge: .top, spacing: 0, content: {
+        .scrollEdgeEffectStyle(.soft, for: .vertical)
+        .safeAreaBar(edge: .bottom, content: {
             VStack(spacing: 0) {
                 HStack {
                     Button {
@@ -192,24 +193,21 @@ struct CommitCreateView: View {
                 .textSelection(.disabled)
                 .padding(.vertical, 10)
                 .padding(.horizontal)
-                Divider()
+
+                CommitMessageEditor(
+                    folder: folder,
+                    commitMessage: $commitMessage,
+                    generatedCommitMessage: $generatedCommitMessage,
+                    generatedCommitMessageIsResponding: $generatedCommitMessageIsResponding,
+                    cachedDiffStat: $cachedDiffStat,
+                    isAmend: $isAmend,
+                    error: $error,
+                    cachedDiffRaw: $cachedDiffRaw,
+                    amendCommit: $amendCommit) {
+                        onCommit()
+                    }
+                    .frame(height: 140)
             }
-        })
-        .scrollEdgeEffectStyle(.hard, for: .vertical)
-        .safeAreaBar(edge: .bottom, content: {
-            CommitMessageEditor(
-                folder: folder,
-                commitMessage: $commitMessage,
-                generatedCommitMessage: $generatedCommitMessage,
-                generatedCommitMessageIsResponding: $generatedCommitMessageIsResponding,
-                cachedDiffStat: $cachedDiffStat,
-                isAmend: $isAmend,
-                error: $error,
-                cachedDiffRaw: $cachedDiffRaw,
-                amendCommit: $amendCommit) {
-                    onCommit()
-                }
-                .frame(height: 140)
         })
         .textSelection(.enabled)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
I’d like to reduce the visual differences between CommitCreateView and CommitDetailView by aligning the placement of the Expand / Collapse controls.

This makes the two views feel more consistent, especially when users move between creating a commit and reviewing committed changes. Keeping the disclosure controls in the same position also makes the UI easier to scan and reduces unnecessary reorientation.

Before
<img width="1112" height="803" alt="スクリーンショット 2026-07-13 14 02 53" src="https://github.com/user-attachments/assets/32c604d9-769d-43b5-a2a4-85693e6e57fc" />


After
<img width="1129" height="811" alt="スクリーンショット 2026-07-13 14 02 39" src="https://github.com/user-attachments/assets/c55d1d11-3c50-4461-b112-9d4d86b2d6e6" />
